### PR TITLE
Fix position of quotes in powershell build script

### DIFF
--- a/tools/build_nodejs.ps1
+++ b/tools/build_nodejs.ps1
@@ -68,5 +68,5 @@ Pop-Location # Undo Push-Location -Path $buildRoot
 Write-Output "`nNode JS has been built and the includes and library files are in:`n"
 Write-Output "`t$buildRoot\dist"
 Write-Output "`nSet the following variables so that the Azure IoT Gateway SDK build scripts can find these files."
-Write-Output "`n`tset NODE_INCLUDE=`"$buildRoot\dist\inc`""
-Write-Output "`tset NODE_LIB=`"$buildRoot\dist\lib`"`n"
+Write-Output "`n`tset `"NODE_INCLUDE=$buildRoot\dist\inc`""
+Write-Output "`tset `"NODE_LIB=$buildRoot\dist\lib`"`n"


### PR DESCRIPTION
The quotes for setting NODE_INCLUDE and NODE_LIB were in the wrong place resulting in build failures where uv.h was not found.

Thanks @avranju for helping debug.