### PR TITLE
Fix Java binding build error on Windows

### DIFF
--- a/bindings/java/gateway-java-binding/pom.xml
+++ b/bindings/java/gateway-java-binding/pom.xml
@@ -55,6 +55,7 @@
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/proxy/gateway/java/gateway-remote-module/pom.xml
+++ b/proxy/gateway/java/gateway-remote-module/pom.xml
@@ -46,6 +46,7 @@
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/java_sample/java_modules/Printer/pom.xml
+++ b/samples/java_sample/java_modules/Printer/pom.xml
@@ -22,6 +22,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/java_sample/java_modules/Sensor/pom.xml
+++ b/samples/java_sample/java_modules/Sensor/pom.xml
@@ -22,6 +22,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR fixes Java binding build error on Windows caused by default java compiler encoding specified by maven.

For your information, there are build error message when I tried on Japanese Windows:
```
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ gateway-java-binding ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding MS932, i.e. build is platform dependent!
[INFO] Compiling 2 source files to path\to\gwsdk\bindings\java\gateway-java-binding\target\test-classes
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[281,27] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[281,33] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[281,40] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[281,46] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[282,27] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[282,38] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[284,36] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[284,42] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[292,25] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[292,31] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[292,59] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[292,65] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[293,25] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[293,57] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[294,37] この文字は、エンコーディングMS932にマップできません
[ERROR] /path/to/gwsdk/bindings/java/gateway-java-binding/src/test/java/tests/unit/com/microsoft/azure/gateway/messaging/MessageTest.java:[294,43] この文字は、エンコーディングMS932にマップできません
```

This PR fixes above compilation errors.
