### PR TITLE
Turn off Node.js out-of-process modules by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ option(enable_dotnet_core_binding "set enable_dotnet_core_binding to ON to build
 option(enable_ble_module "set enable_ble_module to OFF to remove ble module from gateway build (default is ON)" ON)
 option(enable_native_remote_modules "Build the infrastructure required to support native remote modules (default is ON)" ON)
 option(enable_java_remote_modules "Build the infrastructure required to support java remote modules (default is OFF)" OFF)
-option(enable_nodejs_remote_modules "Build the infrastructure required to support Node.js remote modules (default is ON)" ON)
+option(enable_nodejs_remote_modules "Build the infrastructure required to support Node.js apps as remote modules (default is OFF)" OFF)
 option(use_amqp "set use_amqp to ON if amqp is to be used, set to OFF to not use amqp" ON)
 option(use_http "set use_http to ON if http is to be used, set to OFF to not use http" ON)
 option(use_mqtt "set use_mqtt to ON if mqtt is to be used, set to OFF to not use mqtt" ON)

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -43,7 +43,7 @@ This section shows you how to set up a development environment for Azure IoT Edg
 
     ```
     sudo apt-get update 
-    sudo apt-get install curl build-essential libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind libglib2.0-dev libtool autoconf
+    sudo apt-get install curl build-essential libcurl4-openssl-dev git cmake pkg-config libssl-dev uuid-dev valgrind libglib2.0-dev libtool autoconf
     ```
 
     > Note: libglib2.0-dev is required for ble module/sample.

--- a/proxy/gateway/nodejs/package.json
+++ b/proxy/gateway/nodejs/package.json
@@ -19,6 +19,9 @@
     "lint": "jshint --show-non-errors .",
     "test": "mocha"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "author": "Microsoft",
   "license": "MIT"
 }

--- a/samples/nodejs_remote_sample/README.md
+++ b/samples/nodejs_remote_sample/README.md
@@ -12,13 +12,15 @@ This Node.js application uses the `azure-iot-proxy-gateway` package to act as an
 
 To run this sample:
 
+1. Install [Node.js](https://nodejs.org/en/download/) version 6.0 or later.
+
 1. Follow the instructions in the [proxy gateway sample](https://github.com/Azure/iot-edge/blob/master/samples/proxy_sample/README.md) to build and configure an IoT Edge application that communicates with an out-of-process module.
 
-2. In the `proxy/gateway/nodejs` folder, run `npm install` to install the package's dependencies.
+1. In the `proxy/gateway/nodejs` folder, run `npm install` to install the package's dependencies.
 
-3. In the `samples/nodejs_remote_sample` directory, run `npm install` to install the sample's dependencies.
+1. In the `samples/nodejs_remote_sample` directory, run `npm install` to install the sample's dependencies.
 
-4. Start the `proxy_gateway` app from one terminal like this:
+1. Start the `proxy_gateway` app from one terminal like this:
 
     ### Linux/Mac
     ```
@@ -32,7 +34,7 @@ To run this sample:
     Debug\proxy_sample.exe ..\..\..\samples\proxy_sample\src\proxy_sample_win.json
     ```
 
-5. Start the `nodejs_remote_sample` Node.js app from _another_ terminal like this:
+1. Start the `nodejs_remote_sample` Node.js app from _another_ terminal like this:
 
     ### Linux/Mac
     ```

--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -30,7 +30,7 @@ set CMAKE_enable_dotnet_core_binding=OFF
 set enable-java-binding=OFF
 set enable_nodejs_binding=OFF
 set enable_native_remote_modules=ON
-set enable_nodejs_remote_modules=ON
+set enable_nodejs_remote_modules=OFF
 set enable_java_remote_modules=OFF
 set CMAKE_enable_ble_module=ON
 set use_xplat_uuid=OFF
@@ -48,7 +48,7 @@ if "%1" equ "--enable-dotnet-core-binding" goto arg-enable-dotnet-core-binding
 if "%1" equ "--enable-java-binding" goto arg-enable-java-binding
 if "%1" equ "--enable-nodejs-binding" goto arg-enable_nodejs_binding
 if "%1" equ "--disable-native-remote-modules" goto arg-disable_native_remote_modules
-if "%1" equ "--disable-nodejs-remote-modules" goto arg-disable_nodejs_remote_modules
+if "%1" equ "--enable-nodejs-remote-modules" goto arg-enable_nodejs_remote_modules
 if "%1" equ "--enable-java-remote-modules" goto arg-enable-java-remote-modules
 if "%1" equ "--disable-ble-module" goto arg-disable_ble_module
 if "%1" equ "--system-deps-path" goto arg-system-deps-path
@@ -108,8 +108,8 @@ goto args-continue
 set enable_native_remote_modules=OFF
 goto args-continue
 
-:arg-disable_nodejs_remote_modules
-set enable_nodejs_remote_modules=OFF
+:arg-enable_nodejs_remote_modules
+set enable_nodejs_remote_modules=ON
 goto args-continue
 
 :arg-enable-java-remote-modules
@@ -243,8 +243,8 @@ echo  --enable-nodejs-binding         Build Node.js binding
 echo                                  (NODE_INCLUDE, NODE_LIB must be defined)
 echo  --disable-native-remote-modules Do not build the infrastructure required
 echo                                  to support native remote modules
-echo  --disable-nodejs-remote-modules Do not build the infrastructure required
-echo                                  to support native remote modules
+echo  --enable-nodejs-remote-modules  Build the infrastructure required to support
+echo                                  Node.js apps as remote modules
 echo  --enable-java-remote-modules    Build Java Remote modules SDK
 echo                                  (JAVA_HOME must be defined in your environment)
 echo  --platform value                Build platform (e.g. [Win32], x64, ...)

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -16,7 +16,7 @@ enable_java_binding=OFF
 enable_dotnet_core_binding=OFF
 enable_nodejs_binding=OFF
 enable_native_remote_modules=ON
-enable_nodejs_remote_modules=ON
+enable_nodejs_remote_modules=OFF
 enable_java_remote_modules=OFF
 toolchainfile=
 enable_ble_module=ON
@@ -39,8 +39,8 @@ usage ()
     echo "                                 (NODE_INCLUDE, NODE_LIB must be defined)"
     echo " --disable-native-remote-modules Do not build the infrastructure"
     echo "                                 required to support native remote modules"
-    echo " --disable-nodejs-remote-modules Do not build the infrastructure"
-    echo "                                 required to support Node.js remote modules"
+    echo " --enable-nodejs-remote-modules  Build the infrastructure required to support"
+    echo "                                 Node.js apps as remote modules"
     echo " --enable-java-remote-modules    Build Java Remote Module SDK"
     echo "                                 (JAVA_HOME must be defined in your environment)"
     echo " --rebuild-deps                  Force rebuild of dependencies"
@@ -90,7 +90,7 @@ process_args ()
               "--enable-dotnet-core-binding" ) enable_dotnet_core_binding=ON;;
               "--enable-nodejs-binding" ) enable_nodejs_binding=ON;;
               "--disable-native-remote-modules" ) enable_native_remote_modules=OFF;;
-              "--disable-nodejs-remote-modules" ) enable_nodejs_remote_modules=OFF;;
+              "--enable-nodejs-remote-modules" ) enable_nodejs_remote_modules=ON;;
               "--enable-java-remote-modules" ) enable_java_remote_modules=ON;;
               "--disable-ble-module" ) enable_ble_module=OFF;;
               "--toolchain-file" ) save_next_arg=2;;


### PR DESCRIPTION
...because users may not have Node.js installed (or it might be an older version that doesn't meet our requirements).
Also, document that the new Node.js out-of-process modules feature requires at least Node.js v6.0.