### PR TITLE
Don't exit build script if #cores evaluates to zero

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -127,7 +127,7 @@ get_cores ()
 
     if [ "$VSPACE" -lt "$MINVSPACE" ] ; then
     # We think the number of cores to use is a function of available memory divided by 500 MB
-    CORES2=$(expr ${MEMAR[0]} / 500000)
+    CORES2=$(expr ${MEMAR[0]} / 500000) || true
 
     # Clamp the cores to use to be between 1 and $CORES (inclusive)
     CORES2=$([ $CORES2 -le 0 ] && echo 1 || echo $CORES2)


### PR DESCRIPTION
The Linux build script fails silently if the number of cores and the virtual memory on the host machine cause the `CORES2` variable to evaluate to zero. This is because the unix `expr` command returns a non-zero error code if the result is zero, even though zero is a legitimate result. I fixed it by discarding the status code; we only care about the expression result.