### PR TITLE
Remove filter from message printing

### DIFF
--- a/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
+++ b/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
@@ -24,7 +24,17 @@ namespace PrinterModule
 
         public void Receive(Message received_message)
         {
-            Console.WriteLine("Printer Module received message from " + received_message.Properties["source"] + ". Content: " + System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length));
+            if (received_message != null)
+            {
+                string messageData = System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length);
+                Console.WriteLine("{0}> Printer module received message: {1}", DateTime.Now.ToLocalTime(), messageData);
+ 
+                int propCount = 0;
+                foreach (var prop in received_message.Properties)
+                {
+                    Console.WriteLine("\tProperty[{0}]> Key={1} : Value={2}", propCount++, prop.Key, prop.Value);
+                }
+            }
         }
     }
 }

--- a/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
+++ b/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
@@ -24,10 +24,7 @@ namespace PrinterModule
 
         public void Receive(Message received_message)
         {
-            if(received_message.Properties["source"] == "sensor")
-            {
-                Console.WriteLine("Printer Module received message from Sensor. Content: " + System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length));
-            }
+            Console.WriteLine("Printer Module received message from " + received_message.Properties["source"] + ". Content: " + System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length));
         }
     }
 }


### PR DESCRIPTION
When using the printer module to debug solutions it doesn't make sence that only messages coming from "Sensor" is printed.