### PR TITLE
Add sequential order at initalizing phase

### DIFF
--- a/modules/ble/inc/ble.h
+++ b/modules/ble/inc/ble.h
@@ -29,6 +29,8 @@ typedef struct BLE_INSTRUCTION_TAG
     */
     STRING_HANDLE               characteristic_uuid;
 
+    void* nextInst;
+
     union
     {
         /**

--- a/modules/ble/inc/bleio_seq.h
+++ b/modules/ble/inc/bleio_seq.h
@@ -49,6 +49,12 @@ typedef struct BLEIO_SEQ_INSTRUCTION_TAG
      */
     void*                       context;
 
+	/**
+	* Added by H. Ota
+	* instruction_type is equal to SEQUENTIAL then context hold next instructin
+	*/
+    void* nextInst;
+
     union
     {
         /**

--- a/modules/ble/src/ble.c
+++ b/modules/ble/src/ble.c
@@ -56,6 +56,11 @@ static void on_connect_complete(
     BLEIO_GATT_CONNECT_RESULT connect_result
 );
 
+//static void on_disconnect_complete(
+//    BLEIO_GATT_HANDLE bleio_gatt_handle,
+//    void* context
+//);
+
 static void on_read_complete(
     BLEIO_SEQ_HANDLE bleio_seq_handle,
     void* context,
@@ -466,6 +471,7 @@ static VECTOR_HANDLE ble_instr_to_bleioseq_instr(BLE_HANDLE_DATA* module, VECTOR
             // copy the data
             BLEIO_SEQ_INSTRUCTION instr;
             instr.instruction_type = src_instr->instruction_type;
+            instr.nextInst = NULL;
             instr.characteristic_uuid = STRING_clone(src_instr->characteristic_uuid);
 
             if (
@@ -568,7 +574,7 @@ static int format_timestamp(char* dest, size_t dest_size)
              * Note: We record the time only with a granularity of seconds. We
              * may want to increase this to include milliseconds.
              */
-            if (strftime(dest, dest_size, "%Y:%m:%dT%H:%M:%S", t2) == 0)
+            if (strftime(dest, dest_size, "%Y/%m/%dT%H:%M:%S", t2) == 0)
             {
                 LogError("strftime() failed");
                 result = __LINE__;

--- a/modules/ble/src/ble_instr_utils.c
+++ b/modules/ble/src/ble_instr_utils.c
@@ -203,12 +203,15 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
                     }
                     else
                     {
-                        if ( strcmp(type, "sequential") == 0) {
+                        if ( strcmp(type, "sequential") == 0)
+                        {
                             JSON_Array* seq_instructions = json_object_get_array(instr, "instructions");
                             VECTOR_HANDLE seqInsts = parse_instructions(seq_instructions);
-                            if (seqInsts!=NULL){
+                            if (seqInsts!=NULL)
+                            {
                                 size_t numOfSeqs = VECTOR_size(seqInsts);
-                                if (numOfSeqs>0){
+                                if (numOfSeqs>0)
+                                {
   									BLE_INSTRUCTION* prev_instr = (BLE_INSTRUCTION*)VECTOR_element(seqInsts, 0);
 									BLE_INSTRUCTION firstInstr = { 0 };
 									firstInstr.instruction_type = prev_instr->instruction_type;
@@ -216,8 +219,10 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
 									firstInstr.nextInst = NULL;
 									memcpy(&(firstInstr.data), &(prev_instr->data), sizeof(prev_instr->data));
 									prev_instr = &firstInstr;
-									if (numOfSeqs > 1) {
-										for (size_t c = 1; c < numOfSeqs; c++) {
+									if (numOfSeqs > 1)
+                                    {
+										for (size_t c = 1; c < numOfSeqs; c++)
+                                        {
 											BLE_INSTRUCTION* current = (BLE_INSTRUCTION*)VECTOR_element(seqInsts, c);
 											BLE_INSTRUCTION* currentInstr = (BLE_INSTRUCTION*)malloc(sizeof(BLE_INSTRUCTION));
 											currentInstr->instruction_type = current->instruction_type;
@@ -227,13 +232,16 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
 											prev_instr = currentInstr;
 										}
 									}
-									if (VECTOR_push_back(result, &firstInstr, 1) != 0) {
-										// error
+									if (VECTOR_push_back(result, &firstInstr, 1) != 0)
+                                    {
+                                        LogError("VECTOR_push_back return not zero for the property 'characteristic_uuid' for instruction number %zu", i);
 									}
-
                                 }
+                                VECTOR_destroy(seqInsts);
                             }
-                        } else {
+                        }
+                        else
+                        {
                             const char* characteristic_uuid = json_object_get_string(instr, "characteristic_uuid");
                             if (characteristic_uuid == NULL)
                             {

--- a/modules/ble/src/ble_instr_utils.c
+++ b/modules/ble/src/ble_instr_utils.c
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "azure_c_shared_utility/vector.h"
 #include "azure_c_shared_utility/base64.h"
@@ -61,7 +63,6 @@ bool parse_write(
     size_t index
 )
 {
-    (void)index;
     bool result;
     ble_instr->instruction_type = type;
     const char* base64_encoded_data = json_object_get_string(instr, "data");
@@ -96,7 +97,6 @@ bool parse_instruction(
     size_t index
 )
 {
-    (void)index;
     bool result;
     if (strcmp(type, "read_once") == 0)
     {
@@ -203,24 +203,42 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
                     }
                     else
                     {
-                        const char* characteristic_uuid = json_object_get_string(instr, "characteristic_uuid");
-                        if (characteristic_uuid == NULL)
-                        {
-                            /*Codes_SRS_BLE_05_009: [ BLE_CreateFromJson shall return NULL if a given instruction does not have a characteristic_uuid property. ]*/
-                            LogError("json_object_get_string returned NULL for the property 'characteristic_uuid' for instruction number %zu", i);
-                            free_instructions(result);
-                            VECTOR_destroy(result);
-                            result = NULL;
-                            break;
-                        }
-                        else
-                        {
-                            BLE_INSTRUCTION ble_instr = { 0 };
-                            ble_instr.characteristic_uuid = STRING_construct(characteristic_uuid);
-                            if (ble_instr.characteristic_uuid == NULL)
+                        if ( strcmp(type, "sequential") == 0) {
+                            JSON_Array* seq_instructions = json_object_get_array(instr, "instructions");
+                            VECTOR_HANDLE seqInsts = parse_instructions(seq_instructions);
+                            if (seqInsts!=NULL){
+                                size_t numOfSeqs = VECTOR_size(seqInsts);
+                                if (numOfSeqs>0){
+  									BLE_INSTRUCTION* prev_instr = (BLE_INSTRUCTION*)VECTOR_element(seqInsts, 0);
+									BLE_INSTRUCTION firstInstr = { 0 };
+									firstInstr.instruction_type = prev_instr->instruction_type;
+									firstInstr.characteristic_uuid = STRING_clone(prev_instr->characteristic_uuid);
+									firstInstr.nextInst = NULL;
+									memcpy(&(firstInstr.data), &(prev_instr->data), sizeof(prev_instr->data));
+									prev_instr = &firstInstr;
+									if (numOfSeqs > 1) {
+										for (size_t c = 1; c < numOfSeqs; c++) {
+											BLE_INSTRUCTION* current = (BLE_INSTRUCTION*)VECTOR_element(seqInsts, c);
+											BLE_INSTRUCTION* currentInstr = (BLE_INSTRUCTION*)malloc(sizeof(BLE_INSTRUCTION));
+											currentInstr->instruction_type = current->instruction_type;
+											currentInstr->characteristic_uuid = STRING_clone(current->characteristic_uuid);
+											memcpy(&(currentInstr->data), &(current->data), sizeof(current->data));
+											prev_instr->nextInst = currentInstr;
+											prev_instr = currentInstr;
+										}
+									}
+									if (VECTOR_push_back(result, &firstInstr, 1) != 0) {
+										// error
+									}
+
+                                }
+                            }
+                        } else {
+                            const char* characteristic_uuid = json_object_get_string(instr, "characteristic_uuid");
+                            if (characteristic_uuid == NULL)
                             {
-                                /*Codes_SRS_BLE_05_002: [ BLE_CreateFromJson shall return NULL if any of the underlying platform calls fail. ]*/
-                                LogError("STRING_construct returned NULL while processing instruction %zu", i);
+                                /*Codes_SRS_BLE_05_009: [ BLE_CreateFromJson shall return NULL if a given instruction does not have a characteristic_uuid property. ]*/
+                                LogError("json_object_get_string returned NULL for the property 'characteristic_uuid' for instruction number %zu", i);
                                 free_instructions(result);
                                 VECTOR_destroy(result);
                                 result = NULL;
@@ -228,10 +246,12 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
                             }
                             else
                             {
-                                if (parse_instruction(type, instr, &ble_instr, i) == false)
+                                BLE_INSTRUCTION ble_instr = { 0 };
+                                ble_instr.characteristic_uuid = STRING_construct(characteristic_uuid);
+                                if (ble_instr.characteristic_uuid == NULL)
                                 {
-                                    LogError("parse_instruction returned false while processing instruction %zu", i);
-                                    STRING_delete(ble_instr.characteristic_uuid);
+                                    /*Codes_SRS_BLE_05_002: [ BLE_CreateFromJson shall return NULL if any of the underlying platform calls fail. ]*/
+                                    LogError("STRING_construct returned NULL while processing instruction %zu", i);
                                     free_instructions(result);
                                     VECTOR_destroy(result);
                                     result = NULL;
@@ -239,16 +259,28 @@ VECTOR_HANDLE parse_instructions(JSON_Array* instructions)
                                 }
                                 else
                                 {
-                                    // if we get here then we have a valid instruction
-                                    if (VECTOR_push_back(result, &ble_instr, 1) != 0)
+                                    if (parse_instruction(type, instr, &ble_instr, i) == false)
                                     {
-                                        /*Codes_SRS_BLE_05_002: [ BLE_CreateFromJson shall return NULL if any of the underlying platform calls fail. ]*/
-                                        LogError("VECTOR_push_back returned a non-zero value while processing instruction %zu", i);
-                                        free_instruction(&ble_instr);
+                                        LogError("parse_instruction returned false while processing instruction %zu", i);
+                                        STRING_delete(ble_instr.characteristic_uuid);
                                         free_instructions(result);
                                         VECTOR_destroy(result);
                                         result = NULL;
                                         break;
+                                    }
+                                    else
+                                    {
+                                        // if we get here then we have a valid instruction
+                                        if (VECTOR_push_back(result, &ble_instr, 1) != 0)
+                                        {
+                                            /*Codes_SRS_BLE_05_002: [ BLE_CreateFromJson shall return NULL if any of the underlying platform calls fail. ]*/
+                                            LogError("VECTOR_push_back returned a non-zero value while processing instruction %zu", i);
+                                            free_instruction(&ble_instr);
+                                            free_instructions(result);
+                                            VECTOR_destroy(result);
+                                            result = NULL;
+                                            break;
+                                        }
                                     }
                                 }
                             }

--- a/modules/ble/src/bleio_seq_linux.c
+++ b/modules/ble/src/bleio_seq_linux.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -25,6 +26,12 @@ static bool validate_instructions(VECTOR_HANDLE instructions);
 // are still outstanding I/O requests, we want to keep the handle data
 // alive till all of them complete.
 DEFINE_REFCOUNT_TYPE(BLEIO_SEQ_HANDLE_DATA);
+
+// Added by H. Ota
+static void on_seqential_instruction_complete(
+	BLEIO_SEQ_HANDLE_DATA* bleio_seq_handle,
+	BLEIO_SEQ_INSTRUCTION* instruction
+);
 
 BLEIO_SEQ_HANDLE BLEIO_Seq_Create(
     BLEIO_GATT_HANDLE bleio_gatt_handle,
@@ -156,7 +163,6 @@ static bool validate_instructions(VECTOR_HANDLE instructions)
 
     return result;
 }
-
 void inc_ref_handle(BLEIO_SEQ_HANDLE_DATA* handle_data)
 {
     INC_REF(BLEIO_SEQ_HANDLE_DATA, handle_data);
@@ -197,6 +203,16 @@ void dec_ref_handle(BLEIO_SEQ_HANDLE_DATA* handle_data)
                     BUFFER_delete(instruction->data.buffer);
                 }
             }
+            /*
+                added by H. Ota
+            */
+			void* nextInstr = instruction->nextInst;
+			while (nextInstr!=NULL)
+			{
+				void* current = nextInstr;
+				nextInstr = ((BLEIO_SEQ_INSTRUCTION*)current)->nextInst;
+				free(current);
+			}
         }
 
         VECTOR_destroy(handle_data->instructions);
@@ -333,7 +349,9 @@ BLEIO_SEQ_RESULT BLEIO_Seq_Run(BLEIO_SEQ_HANDLE bleio_seq_handle)
                 // schedule this instruction only if it is not a WRITE_AT_EXIT instruction
                 if (instruction->instruction_type != WRITE_AT_EXIT)
                 {
-                    result = schedule_instruction(handle_data, instruction, NULL);
+                    // Modified by H. Ota
+                    //  result = schedule_instruction(handle_data, instruction, NULL);
+                    result = schedule_instruction(handle_data, instruction, on_seqential_instruction_complete);
 
                     // bail if a schedule operation didn't succeed
                     if (result != BLEIO_SEQ_OK)
@@ -373,6 +391,23 @@ static void on_instruction_complete(
     // free the instruction
     free(instruction);
 }
+
+// Added by H. Ota. this method is called for sequential instruction
+static void on_seqential_instruction_complete(
+	BLEIO_SEQ_HANDLE_DATA* bleio_seq_handle,
+	BLEIO_SEQ_INSTRUCTION* instruction
+)
+{
+	if (instruction->nextInst != NULL) {
+		BLEIO_SEQ_RESULT result = schedule_instruction(bleio_seq_handle, instruction->nextInst, on_seqential_instruction_complete);
+		if (result != BLEIO_SEQ_OK)
+		{
+			LogError("An error occurred while child scheduling an instruction of type %d for characteristic %s",
+				instruction->instruction_type, STRING_c_str(instruction->characteristic_uuid));
+		}
+	}
+}
+
 
 BLEIO_SEQ_RESULT BLEIO_Seq_AddInstruction(
     BLEIO_SEQ_HANDLE bleio_seq_handle,


### PR DESCRIPTION
Current logic support only asynchronous BLE instruction in initializing phase.
But in the TI Sensor Tag CC2541 case, sequential order is necessary.
http://processors.wiki.ti.com/index.php/SensorTag_User_Guide#Barometric_Pressure_Sensor_2
I add feature to support sequential order in initializing phase.
You can specify "calibration enable -> read calibration -> sensor enable" sequence by
```
      "args": {
        "controller_index": 0,
        "device_mac_address": "<<Sensor Tag MAC ADDRESS - AA:BB:CC:DD:EE:FF>>",
        "instructions": [
          {
            "type":  "sequential",
            "instructions": [
              {
                "type": "write_at_init",
                "characteristic_uuid": "F000AA42-0451-4000-B000-000000000000",
                "data": "Ag==",
                "description" : "enable presssure sensor calibration"
              },
              {
                "type": "read_once",
                "characteristic_uuid": "F000AA43-0451-4000-B000-000000000000",
                "description":"read pressure sensor calibration config"
              },
              {
                "type": "write_at_init",
                "characteristic_uuid": "F000AA42-0451-4000-B000-000000000000",
                "data": "AQ==",
                "description":"enable pressure sensor"
              }
            ],
            "description" : "'sequence' type guarantees execution in the defined instruction order"
          },
          {
            "type": "write_at_init",
            "characteristic_uuid": "F000AA12-0451-4000-B000-000000000000",
            "data": "AQ=="
          },
```
I've published whole sample which use this modification from https://github.com/ms-iotkithol-jp/AzureIoTGatewaySDKExtention/tree/master/samples/ble_json_gateway .
Please refer that also.

I do not care about the keywords, names and styles used separately. If there are more nice styles and keywords else, I hope you will adopt that.
