### PR TITLE
Fix #276: Support macOS builds from build.sh

### DIFF
--- a/jenkins/osx_c.sh
+++ b/jenkins/osx_c.sh
@@ -3,52 +3,16 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-set -e
+build_root=$(cd "$(dirname "$0")/.." && pwd)
+cd $build_root
 
-script_dir=$(cd "$(dirname "$0")" && pwd)
-build_root=$(cd "${script_dir}/.." && pwd)
-build_folder=$build_root"/build"
-
-CORES=$(sysctl -n hw.ncpu)
-
-# Java binding
-pushd $build_root/bindings/java/gateway-java-binding
-mvn clean install
-popd
-
-# Java proxy gateway
-pushd $build_root/proxy/gateway/java/gateway-remote-module
-mvn clean install
-popd
-
-# Node.js proxy gateway
-pushd $build_root/proxy/gateway/nodejs
-npm install
-npm run lint
-npm test
-popd
-
-# Node.js proxy gateway sample
-pushd $build_root/samples/nodejs_remote_sample
-npm install
-npm run lint
-popd
-
-rm -rf $build_folder
-mkdir -p $build_folder
-pushd $build_folder
-
-cmake \
-    -Ddependency_install_prefix:PATH=$build_root/install-deps \
-    -DOPENSSL_ROOT_DIR:PATH=/usr/local/opt/openssl \
-    -Dbuild_cores=$CORES \
-    -Denable_ble_module:BOOL=OFF \
-    -Denable_java_binding=ON \
-    -Denable_java_remote_modules:BOOL=ON \
-    -Drun_unittests:BOOL=ON \
-    -Drun_e2e_tests:BOOL=ON \
-    ..
-
-cmake --build . -- --jobs=$CORES
-ctest -C "debug" -V
-popd
+OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+tools/build.sh \
+    --disable-ble-module \
+    --enable-java-binding \
+    --enable-java-remote-modules \
+    --enable-nodejs-remote-modules \
+    --run-unittests \
+    --run-e2e-tests \
+    "$@" #-x
+[ $? -eq 0 ] || exit $?

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -113,25 +113,30 @@ get_cores ()
 {
     CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 
-    # Make sure there is enough virtual memory on the device to handle more than one job.
-    # We arbitrarily decide that 500 MB per core is what we need in order to run the build
-    # in parallel.
-    MINVSPACE=$(expr 500000 \* $CORES)
+    # The following logic works on Linux, doesn't work on macOS. For now, we'll assume macOS
+    # devices have enough memory per core to run the build, rather than porting this logic.
+    if [[ $(uname -s) != Darwin ]]
+    then
+        # Make sure there is enough virtual memory on the device to handle more than one job.
+        # We arbitrarily decide that 500 MB per core is what we need in order to run the build
+        # in parallel.
+        MINVSPACE=$(expr 500000 \* $CORES)
 
-    # Acquire total memory and total swap space setting them to zero in the event the command fails
-    MEMAR=( $(sed -n -e 's/^MemTotal:[^0-9]*\([0-9][0-9]*\).*/\1/p' -e 's/^SwapTotal:[^0-9]*\([0-9][0-9]*\).*/\1/p' /proc/meminfo) )
-    [ -z "${MEMAR[0]##*[!0-9]*}" ] && MEMAR[0]=0
-    [ -z "${MEMAR[1]##*[!0-9]*}" ] && MEMAR[1]=0
+        # Acquire total memory and total swap space setting them to zero in the event the command fails
+        MEMAR=( $(sed -n -e 's/^MemTotal:[^0-9]*\([0-9][0-9]*\).*/\1/p' -e 's/^SwapTotal:[^0-9]*\([0-9][0-9]*\).*/\1/p' /proc/meminfo) )
+        [ -z "${MEMAR[0]##*[!0-9]*}" ] && MEMAR[0]=0
+        [ -z "${MEMAR[1]##*[!0-9]*}" ] && MEMAR[1]=0
 
-    let VSPACE=${MEMAR[0]}+${MEMAR[1]}
+        let VSPACE=${MEMAR[0]}+${MEMAR[1]}
 
-    if [ "$VSPACE" -lt "$MINVSPACE" ] ; then
-    # We think the number of cores to use is a function of available memory divided by 500 MB
-    CORES2=$(expr ${MEMAR[0]} / 500000) || true
+        if [ "$VSPACE" -lt "$MINVSPACE" ] ; then
+            # We think the number of cores to use is a function of available memory divided by 500 MB
+            CORES2=$(expr ${MEMAR[0]} / 500000) || true
 
-    # Clamp the cores to use to be between 1 and $CORES (inclusive)
-    CORES2=$([ $CORES2 -le 0 ] && echo 1 || echo $CORES2)
-    CORES=$([ $CORES -le $CORES2 ] && echo $CORES || echo $CORES2)
+            # Clamp the cores to use to be between 1 and $CORES (inclusive)
+            CORES2=$([ $CORES2 -le 0 ] && echo 1 || echo $CORES2)
+            CORES=$([ $CORES -le $CORES2 ] && echo $CORES || echo $CORES2)
+        fi
     fi
 }
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -19,10 +19,16 @@ enable_native_remote_modules=ON
 enable_nodejs_remote_modules=OFF
 enable_java_remote_modules=OFF
 toolchainfile=
-enable_ble_module=ON
 dependency_install_prefix="-Ddependency_install_prefix=$local_install"
 build_config=Debug
 use_xplat_uuid=OFF
+if [[ $(uname -s) == Darwin ]]
+then
+    # Don't build BLE for macOS, even if the caller doesn't pass `--disable-ble-module`
+    enable_ble_module=OFF
+else
+    enable_ble_module=ON
+fi
 
 usage ()
 {


### PR DESCRIPTION
Until now you had to use CMake commands directly (or call jenkins/osx_c.sh). Now you can use tools/build.sh. Note that you need to pass the right flags, e.g., macOS doesn't support our BLE module so you have to pass `--disable-ble-module`.

The only problem was the logic we use to calculate available memory per core. I simply bypassed that logic for macOS; we can assume for now that macOS devices have enough memory per core to build without getting bogged down.