### PR TITLE
Add Jenkins script for Win64 VS2017 builds

### DIFF
--- a/jenkins/windows_x64_no_remote_modules_c.cmd
+++ b/jenkins/windows_x64_no_remote_modules_c.cmd
@@ -1,0 +1,15 @@
+@REM Copyright (c) Microsoft. All rights reserved.
+@REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+setlocal
+
+set build-root=%~dp0..
+rem // resolve to fully qualified path
+for %%i in ("%build-root%") do set build-root=%%~fi
+
+set "JAVA_HOME=%JAVA_8_64%"
+set "PATH=%JAVA_HOME%\bin;%JAVA_HOME%\jre\bin\server;%PATH%;%NODE_LIB%"
+
+cd %build-root%\tools
+call build.cmd --run-unittests --run-e2e-tests --enable-nodejs-binding --enable-dotnet-binding --enable-dotnet-core-binding --enable-java-binding %*
+if errorlevel 1 exit /b 1


### PR DESCRIPTION
We needed a jenkins script for the new Windows x64 VS 2017 gated build we're adding. This build doesn't include remote module support, since that requires libuv, which doesn't yet build with VS2017.