### PR TITLE
Lock LibUV to commit w/ VS2017 support

### DIFF
--- a/tools/build_libuv.cmd
+++ b/tools/build_libuv.cmd
@@ -23,7 +23,7 @@ pushd %build-root%
 rem Clone libuv
 git clone https://github.com/libuv/libuv.git
 pushd libuv
-git checkout -b v1.10.1 tags/v1.10.1
+git checkout -b v1.13.0 tags/v1.13.0
 
 rem The following 2 variables must be un-defined because libuv's
 rem vcbuild.bat skips its VS version detection code if these are

--- a/tools/build_libuv.sh
+++ b/tools/build_libuv.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 # Copyright (c) Microsoft. All rights reserved.
@@ -19,7 +20,7 @@ mkdir -p $build_root
 pushd $build_root
 git clone https://github.com/libuv/libuv.git
 cd libuv
-git checkout -b v1.11.0 tags/v1.11.0
+git checkout -b v1.13.0 tags/v1.13.0
 sh autogen.sh
 ./configure --prefix=$prefix --libdir=$libdir CFLAGS='-fPIC' CXXFLAGS='-fPIC'
 make -j $(nproc)


### PR DESCRIPTION
Addresses #218, by snapping to latest LibUV release.