### PR TITLE
Modify CMake files to install to CMAKE_INSTALL_PREFIX

### DIFF
--- a/dependencies-test.cmake
+++ b/dependencies-test.cmake
@@ -6,14 +6,14 @@ include("gatewayFunctions.cmake")
 ###############################################################################
 ############################Find/Install/Build ctest###########################
 ###############################################################################
-findAndInstall(ctest 1.1.0 ${PROJECT_SOURCE_DIR}/deps/ctest ${PROJECT_SOURCE_DIR}/deps/ctest -G "${CMAKE_GENERATOR}")
+findAndInstall(ctest 1.1.0 ${PROJECT_SOURCE_DIR}/deps/ctest ${PROJECT_SOURCE_DIR}/deps/ctest -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 
 ###############################################################################
 #########################Find/Install/Build testrunner#########################
 ###############################################################################
-findAndInstall(testrunnerswitcher 1.1.0 ${PROJECT_SOURCE_DIR}/deps/testrunner ${PROJECT_SOURCE_DIR}/deps/testrunner -G "${CMAKE_GENERATOR}")
+findAndInstall(testrunnerswitcher 1.1.0 ${PROJECT_SOURCE_DIR}/deps/testrunner ${PROJECT_SOURCE_DIR}/deps/testrunner -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 
 ###############################################################################
 ###########################Find/Install/Build umock############################
 ###############################################################################
-findAndInstall(umock_c 1.1.0 ${PROJECT_SOURCE_DIR}/deps/umock-c ${PROJECT_SOURCE_DIR}/deps/umock-c -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}")
+findAndInstall(umock_c 1.1.0 ${PROJECT_SOURCE_DIR}/deps/umock-c ${PROJECT_SOURCE_DIR}/deps/umock-c -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -24,7 +24,7 @@ findAndInstall(azure_c_shared_utility 1.0.25
     -Duse_default_uuid=${use_xplat_uuid}
     -Duse_condition=${enable_event_system}
     ${PASSVARS}
-    -G "${CMAKE_GENERATOR}")
+    -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 set(SHARED_UTIL_INC_FOLDER ${AZURE_C_SHARED_UTILITY_INCLUDE_DIR} CACHE INTERNAL "this is what needs to be included if using sharedLib lib" FORCE)
 set(SHARED_UTIL_LIB_FOLDER ${AZURE_C_SHARED_LIBRARY_DIR} CACHE INTERNAL "this is what needs to be included if using sharedLib lib" FORCE)
 set(SHARED_UTIL_LIB aziotsharedutil CACHE INTERNAL "this is what needs to be included if using sharedLib lib" FORCE)
@@ -66,7 +66,8 @@ else()
             ${PROJECT_SOURCE_DIR}/deps/nanomsg
             -G "${CMAKE_GENERATOR}"
             -DNN_TESTS=OFF
-            -DNN_TOOLS=OFF)
+            -DNN_TOOLS=OFF
+	    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
     endif()
 
     #If earlier cmake

--- a/modules/dependencies.cmake
+++ b/modules/dependencies.cmake
@@ -6,12 +6,12 @@ include("../gatewayFunctions.cmake")
 ###############################################################################
 ###########################Find/Install/Build uamqp############################
 ###############################################################################
-findAndInstall(uamqp 1.0.25 ${PROJECT_SOURCE_DIR}/deps/uamqp ${PROJECT_SOURCE_DIR}/deps/uamqp -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}")
+findAndInstall(uamqp 1.0.25 ${PROJECT_SOURCE_DIR}/deps/uamqp ${PROJECT_SOURCE_DIR}/deps/uamqp -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 
 ###############################################################################
 ###########################Find/Install/Build umqtt############################
 ###############################################################################
-findAndInstall(umqtt 1.0.25 ${PROJECT_SOURCE_DIR}/deps/umqtt ${PROJECT_SOURCE_DIR}/deps/umqtt -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}")
+findAndInstall(umqtt 1.0.25 ${PROJECT_SOURCE_DIR}/deps/umqtt ${PROJECT_SOURCE_DIR}/deps/umqtt -Duse_installed_dependencies=ON -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 
 ###############################################################################
 #######################Find/Install/Build azure_iot_sdks#######################
@@ -36,4 +36,4 @@ if(NOT EXISTS ${PROJECT_SOURCE_DIR}/deps/iot-sdk-c/parson/README.md)
         message(FATAL_ERROR "Error pulling parson submodule: ${res}")
     endif()
 endif()
-findAndInstall(azure_iot_sdks 1.1.5 ${PROJECT_SOURCE_DIR}/deps/iot-sdk-c ${PROJECT_SOURCE_DIR}/deps/iot-sdk-c -Duse_installed_dependencies=ON -Duse_openssl=OFF -Dbuild_as_dynamic=ON -Dskip_samples=ON -G "${CMAKE_GENERATOR}")
+findAndInstall(azure_iot_sdks 1.1.5 ${PROJECT_SOURCE_DIR}/deps/iot-sdk-c ${PROJECT_SOURCE_DIR}/deps/iot-sdk-c -Duse_installed_dependencies=ON -Duse_openssl=OFF -Dbuild_as_dynamic=ON -Dskip_samples=ON -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
When not installing in /usr (because a different location is required or because root access is not available), the CMAKE_INSTALL_PREFIX variable is not passed to the dependencies, causing the build to fail. This commit passes the CMAKE_INSTALL_PREFIX variable to all child CMake processes. With these changes, a "cmake -DCMAKE_INSTALL_PREFIX=/home/.../local .." does build and install in /home/.../local.