### PR TITLE
Ignore certain directories that have moved to /v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,14 +203,14 @@ tools/jenkins-cli.jar
 **/.idea/
 
 # VS Code stuff
-typings/**
-.vscode/**
+typings/
+.vscode/
 
 # ignore cmake build folder
-.cmake/**
-*build/**
-build_nodejs/**
-build_libuv/**
+.cmake/
+*build/
+build_nodejs/
+build_libuv/
 
 # ignore Atom Editor files
 .atom-build.json


### PR DESCRIPTION
Some directories that used to be ignored are now listed in `git status` because we moved everything under the `/v1` folder. This tweak to the `.gitignore` file fixes that.