### PR TITLE
Add avoid message lost of nanomsg features by thread messaging mechanism

### DIFF
--- a/v1/core/inc/broker.h
+++ b/v1/core/inc/broker.h
@@ -30,6 +30,15 @@ extern "C"
 #include <stddef.h>
 #endif
 
+#define BROKER_LINK_MESSAGE_TYPE_VALUES \
+    BROKER_LINK_MESSAGE_TYPE_DEFAULT, \
+    BROKER_LINK_MESSAGE_TYPE_THREAD
+
+/** @brief      Enumeration describing the value of : GATEWA_LINK_ENTRY.message_type
+*/
+DEFINE_ENUM(BROKER_LINK_MESSAGE_TYPE, BROKER_LINK_MESSAGE_TYPE_VALUES);
+
+
 /** @brief    Link Data with #MODULE_HANDLE for source and sink. 
 */
 typedef struct BROKER_LINK_DATA_TAG {
@@ -39,6 +48,9 @@ typedef struct BROKER_LINK_DATA_TAG {
     /** @brief    #MODULE_HANDLE representing the module receiving messages. 
     */
     MODULE_HANDLE module_sink_handle;
+    /** @brief    #message_type representing the message type between sink and source.
+    */
+    BROKER_LINK_MESSAGE_TYPE message_type;
 } BROKER_LINK_DATA;
 
 #define BROKER_RESULT_VALUES \

--- a/v1/core/inc/gateway.h
+++ b/v1/core/inc/gateway.h
@@ -56,6 +56,13 @@ DEFINE_ENUM(GATEWAY_START_RESULT, GATEWAY_START_RESULT_VALUES);
 */
 DEFINE_ENUM(GATEWAY_UPDATE_FROM_JSON_RESULT, GATEWAY_UPDATE_FROM_JSON_RESULT_VALUES);
 
+#define GATEWAY_LINK_ENTRY_MESSAGE_TYPE_VALUES \
+    GATEWAY_LINK_ENTRY_MESSAGE_TYPE_DEFAULT, \
+    GATEWAY_LINK_ENTRY_MESSAGE_TYPE_THREAD
+
+/** @brief      Enumeration describing the value of : GATEWA_LINK_ENTRY.message_type
+*/
+DEFINE_ENUM(GATEWAY_LINK_ENTRY_MESSAGE_TYPE, GATEWAY_LINK_ENTRY_MESSAGE_TYPE_VALUES);
 
 /** @brief      Struct representing a single link for a gateway. */
 typedef struct GATEWAY_LINK_ENTRY_TAG
@@ -65,6 +72,9 @@ typedef struct GATEWAY_LINK_ENTRY_TAG
 
     /** @brief  The name of the module which is going to receive messages. */
     const char* module_sink;
+
+    /** @brief  The name of the message type between sink and source */
+    GATEWAY_LINK_ENTRY_MESSAGE_TYPE message_type;
 } GATEWAY_LINK_ENTRY;
 
 /** @brief      Struct representing a particular gateway. */

--- a/v1/core/inc/module.h
+++ b/v1/core/inc/module.h
@@ -30,7 +30,7 @@ typedef struct MODULE_API_TAG MODULE_API;
 #include "azure_c_shared_utility/macro_utils.h"
 #include "broker.h"
 #include "message.h"
-
+#include "module_loader.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -47,6 +47,7 @@ extern "C"
         const MODULE_API* module_apis;
         /** @brief  HANDLE for module. */
         MODULE_HANDLE module_handle;
+        MODULE_LOADER_TYPE module_loader_type;
     };
 
     /** @brief      Translates module configuration from a JSON string to a

--- a/v1/core/src/broker.c
+++ b/v1/core/src/broker.c
@@ -726,10 +726,10 @@ static int thread_message_control_receiver_thread_worker(void* context)
                 THREAD_MESSAGE_CTRL* pre_receive_msg = NULL;
                 THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* sender = receiverContext->senders;
                 while (sender != NULL) {
-                    if (Lock(sender->sender_module_info->senderThMsg->lock) != LOCK_OK) {
-                        LogError("Lock for senderThMsg in thread_message_control_receiver_thread_worker failed");
-                    }
-                    else {
+//                  if (Lock(sender->sender_module_info->senderThMsg->lock) != LOCK_OK) {
+//                      LogError("Lock for senderThMsg in thread_message_control_receiver_thread_worker failed");
+//                  }
+//                  else {
                         THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* current_receiver = sender->sender_module_info->senderThMsg->receivers;
                         while (current_receiver != NULL) {
                             if (current_receiver->receiver == receiverContext) {
@@ -754,16 +754,20 @@ static int thread_message_control_receiver_thread_worker(void* context)
                         }
                         THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* current_sender = sender;
                         sender = sender->next;
-                        if (Unlock(current_sender->sender_module_info->senderThMsg->lock) != LOCK_OK) {
-                            LogError("Unock for senderThMsg in thread_message_control_receiver_thread_worker failed");
-                        }
+//                      if (Unlock(current_sender->sender_module_info->senderThMsg->lock) != LOCK_OK) {
+//                          LogError("Unock for senderThMsg in thread_message_control_receiver_thread_worker failed");
+//                      }
                     }
                     if (msgCtrl == NULL) {
+                        if (!receiverContext->toContinue) {
+                            LogInfo("Received stop order so that exit message loop!");
+                            break;
+                        }
                         if (Condition_Wait(receiverContext->condition, receiverContext->lock, 0) != COND_OK) {
                             LogError("Wait for condition for receiverContext in thread_message_control_receiver_thread_worker failed");
                         }
                     }
-                }
+//                }
                 THREAD_MESSAGE_CTRL* current_msg = msgCtrl;
                 Unlock(receiverContext->lock);
                 while (current_msg != NULL) {

--- a/v1/core/src/broker.c
+++ b/v1/core/src/broker.c
@@ -751,6 +751,7 @@ static int thread_message_control_receiver_thread_worker(void* context)
                                 current_receiver->sendingMessages = NULL;
                                 break;
                             }
+                            current_receiver = current_receiver->next;
                         }
                         THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* current_sender = sender;
                         sender = sender->next;

--- a/v1/core/src/broker.c
+++ b/v1/core/src/broker.c
@@ -8,6 +8,7 @@
 #include "azure_c_shared_utility/vector.h"
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/lock.h"
+#include "azure_c_shared_utility/condition.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/refcount.h"
@@ -39,6 +40,32 @@ typedef struct BROKER_HANDLE_DATA_TAG
 
 DEFINE_REFCOUNT_TYPE(BROKER_HANDLE_DATA);
 
+typedef struct THREAD_MESSAGE_CTRL_TAG {
+    MESSAGE_HANDLE msg;
+    void* next;
+} THREAD_MESSAGE_CTRL;
+
+typedef struct THREAD_MESSAGE_HANDLING_RECEIVER_TAG {
+    LOCK_HANDLE lock;
+    COND_HANDLE condition;
+    THREAD_HANDLE receiver_thread;
+    void* module_info;  // this type should be BROKER_MODULEINFO*
+    void* senders;  // this type should be THREAD_MESSAGE_HANDLING_SENDERS_IN_RECEIVER
+    bool toContinue;
+} THREAD_MESSAGE_HANDLING_RECEIVER;
+
+typedef struct THREAD_MESSAGE_HANDLING_RECEIVERS_IN_SENDER_TAG{
+    THREAD_MESSAGE_HANDLING_RECEIVER* receiver;
+    THREAD_MESSAGE_CTRL*    sendingMessages;
+    void* next;
+} THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER;
+
+typedef struct THREAD_MESSAGE_HANDLING_SENDER_TAG {
+    LOCK_HANDLE lock;
+    THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* receivers;
+} THREAD_MESSAGE_HANDLING_SENDER;
+
+
 typedef struct BROKER_MODULEINFO_TAG
 {
     /** Handle to the module that's associated with the broker */
@@ -54,7 +81,19 @@ typedef struct BROKER_MODULEINFO_TAG
     /** Guid sent to module worker thread to close task */
     STRING_HANDLE   quit_message_guid;
 
+    LOCK_HANDLE     fc_lock;
+
+    THREAD_MESSAGE_HANDLING_SENDER*   senderThMsg;
+    THREAD_MESSAGE_HANDLING_RECEIVER* receiverThMsg;
+
 }BROKER_MODULEINFO;
+
+typedef struct THREAD_MESSASGE_HANDLING_SENDER_FOR_RECEIVER_TAG {
+    BROKER_MODULEINFO* sender_module_info;
+    void* next;
+} THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER;
+
+
 
 static STRING_HANDLE construct_url()
 {
@@ -202,7 +241,7 @@ static int module_worker(void * user_data)
     while (should_continue)
     {
         /*Codes_SRS_BROKER_13_089: [ This function shall acquire the lock on module_info->socket_lock. ]*/
-        if (Lock(module_info->socket_lock))
+        if (Lock(module_info->socket_lock) != LOCK_OK)
         {
             /*Codes_SRS_BROKER_02_004: [ If acquiring the lock fails, then module_worker shall return. ]*/
             LogError("unable to Lock");
@@ -233,7 +272,7 @@ static int module_worker(void * user_data)
             /*Codes_SRS_BROKER_17_006: [ An error on receiving a message shall terminate the loop. ]*/
             should_continue = 0;
         }
-        else
+        if (should_continue!=0)
         {
             if (nbytes == BROKER_GUID_SIZE &&
                 (strncmp(STRING_c_str(module_info->quit_message_guid), (const char *)buf, BROKER_GUID_SIZE-1)==0))
@@ -242,7 +281,16 @@ static int module_worker(void * user_data)
                 /* received special quit message for this module */
                 should_continue = 0;
             }
-            else
+            if (module_info->receiverThMsg != NULL) {
+                if (Lock(module_info->receiverThMsg->lock) != LOCK_OK) {
+                    LogError("The lock for receiverThMsg in module_worker failed!");
+                }
+                else {
+                    // to check this message come from and ...
+                    Unlock(module_info->receiverThMsg->lock);
+                }
+            }
+            if(should_continue!=0)
             {
                 /*Codes_SRS_BROKER_17_024: [ The function shall strip off the topic from the message. ]*/
                 const unsigned char*buf_bytes = (const unsigned char*)buf;
@@ -281,6 +329,7 @@ static BROKER_RESULT init_module(BROKER_MODULEINFO* module_info, const MODULE* m
     {
         module_info->module->module_apis = module->module_apis;
         module_info->module->module_handle = module->module_handle;
+        module_info->module->module_loader_type = module->module_loader_type;
 
         /*Codes_SRS_BROKER_13_099: [The function shall initialize BROKER_MODULEINFO::socket_lock with a valid lock handle.]*/
         module_info->socket_lock = Lock_Init();
@@ -294,29 +343,32 @@ static BROKER_RESULT init_module(BROKER_MODULEINFO* module_info, const MODULE* m
         {
             char uuid[BROKER_GUID_SIZE];
             memset(uuid, 0, BROKER_GUID_SIZE);
-            /*Codes_SRS_BROKER_17_020: [ The function shall create a unique ID used as a quit signal. ]*/
-            if (UniqueId_Generate(uuid, BROKER_GUID_SIZE) != UNIQUEID_OK)
-            {
-                /*Codes_SRS_BROKER_13_047: [ This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise. ]*/
-                LogError("Lock_Init for socket lock failed");
-                Lock_Deinit(module_info->socket_lock);
-                result = BROKER_ERROR;
-            }
-            else
-            {
-                module_info->quit_message_guid = STRING_construct(uuid);
-                if (module_info->quit_message_guid == NULL)
-                {
-                    /*Codes_SRS_BROKER_13_047: [ This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise. ]*/
-                    LogError("String construct failed for module guid");
-                    Lock_Deinit(module_info->socket_lock);
-                    result = BROKER_ERROR;
-                }
-                else
-                {
-                    result = BROKER_OK;
-                }
-            }
+/*Codes_SRS_BROKER_17_020: [ The function shall create a unique ID used as a quit signal. ]*/
+if (UniqueId_Generate(uuid, BROKER_GUID_SIZE) != UNIQUEID_OK)
+{
+    /*Codes_SRS_BROKER_13_047: [ This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise. ]*/
+    LogError("Lock_Init for socket lock failed");
+    Lock_Deinit(module_info->socket_lock);
+    result = BROKER_ERROR;
+}
+else
+{
+    module_info->quit_message_guid = STRING_construct(uuid);
+    if (module_info->quit_message_guid == NULL)
+    {
+        /*Codes_SRS_BROKER_13_047: [ This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise. ]*/
+        LogError("String construct failed for module guid");
+        Lock_Deinit(module_info->socket_lock);
+        result = BROKER_ERROR;
+    }
+    else
+    {
+        result = BROKER_OK;
+    }
+}
+        }
+        if (result == BROKER_OK) {
+            module_info->fc_lock = Lock_Init();
         }
     }
     return result;
@@ -326,7 +378,38 @@ static void deinit_module(BROKER_MODULEINFO* module_info)
 {
     /*Codes_SRS_BROKER_13_057: [The function shall free all members of the MODULE_INFO object.]*/
     Lock_Deinit(module_info->socket_lock);
+    Lock_Deinit(module_info->fc_lock);
+
     STRING_delete(module_info->quit_message_guid);
+
+    if (module_info->senderThMsg != NULL) {
+        // Can I think senderThMsg has no receiver and no sending message?
+        free((void*)module_info->senderThMsg);
+    }
+    if (module_info->receiverThMsg != NULL) {
+        // Can I think receiverThMsg has no sender?
+        if (Lock(module_info->receiverThMsg->lock) != LOCK_OK) {
+            LogError("lock for receiverThMsg in deinit_module failed!");
+        }
+        else {
+            module_info->receiverThMsg->toContinue = false;
+            COND_RESULT cond_result = Condition_Post(module_info->receiverThMsg->condition);
+            if (cond_result == COND_OK) {
+                if (Unlock(module_info->receiverThMsg->lock) == LOCK_OK) {
+                    int threadResult = 0;
+                    ThreadAPI_Join(module_info->receiverThMsg->receiver_thread, &threadResult);
+                }
+                else {
+                    LogError("unlock for receiverThMsg failed.");
+                }
+            }
+            else {
+                LogError("Post for receiveThMsg in deinit_module doesn't return COND_OK. value was %d", cond_result);
+            }
+        }
+        free((void*)module_info->receiverThMsg);
+    }
+
     free(module_info->module);
 }
 
@@ -449,92 +532,6 @@ static int stop_module(int publish_socket, BROKER_MODULEINFO* module_info)
     return result;
 }
 
-BROKER_RESULT Broker_AddModule(BROKER_HANDLE broker, const MODULE* module)
-{
-    BROKER_RESULT result;
-
-    /*Codes_SRS_BROKER_99_013: [If `broker` or `module` is NULL the function shall return BROKER_INVALIDARG.]*/
-    if (broker == NULL || module == NULL)
-    {
-        result = BROKER_INVALIDARG;
-        LogError("invalid parameter (NULL).");
-    }
-    /*Codes_SRS_BROKER_99_014: [If `module_handle` or `module_apis` are `NULL` the function shall return `BROKER_INVALIDARG`.]*/
-    else if (module->module_apis == NULL || module->module_handle == NULL)
-    {
-        result = BROKER_INVALIDARG;
-        LogError("invalid parameter (NULL).");
-    }
-    else
-    {
-        BROKER_MODULEINFO* module_info = (BROKER_MODULEINFO*)malloc(sizeof(BROKER_MODULEINFO));
-        if (module_info == NULL)
-        {
-            LogError("Allocate module info failed");
-            result = BROKER_ERROR;
-        }
-        else
-        {
-            if (init_module(module_info, module) != BROKER_OK)
-            {
-                /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                LogError("start_module failed");
-                free(module_info->module);
-                free(module_info);
-                result = BROKER_ERROR;
-            }
-            else
-            {
-                /*Codes_SRS_BROKER_13_039: [This function shall acquire the lock on BROKER_HANDLE_DATA::modules_lock.]*/
-                BROKER_HANDLE_DATA* broker_data = (BROKER_HANDLE_DATA*)broker;
-                if (Lock(broker_data->modules_lock) != LOCK_OK)
-                {
-                    /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                    LogError("Lock on broker_data->modules_lock failed");
-                    deinit_module(module_info);
-                    free(module_info);
-                    result = BROKER_ERROR;
-                }
-                else
-                {
-                    /*Codes_SRS_BROKER_13_045: [Broker_AddModule shall append the new instance of BROKER_MODULEINFO to BROKER_HANDLE_DATA::modules.]*/
-                    LIST_ITEM_HANDLE moduleListItem = singlylinkedlist_add(broker_data->modules, module_info);
-                    if (moduleListItem == NULL)
-                    {
-                        /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                        LogError("singlylinkedlist_add failed");
-                        deinit_module(module_info);
-                        free(module_info);
-                        result = BROKER_ERROR;
-                    }
-                    else
-                    {
-                        if (start_module(module_info, broker_data->url) != BROKER_OK)
-                        {
-                            LogError("start_module failed");
-                            deinit_module(module_info);
-                            singlylinkedlist_remove(broker_data->modules, moduleListItem);
-                            free(module_info);
-                            result = BROKER_ERROR;
-                        }
-                        else
-                        {
-                            /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                            result = BROKER_OK;
-                        }
-                    }
-
-                    /*Codes_SRS_BROKER_13_046: [This function shall release the lock on BROKER_HANDLE_DATA::modules_lock.]*/
-                    Unlock(broker_data->modules_lock);
-                }
-            }
-
-        }
-    }
-
-    return result;
-}
-
 static bool find_module_predicate(LIST_ITEM_HANDLE list_item, const void* value)
 {
     BROKER_MODULEINFO* element = (BROKER_MODULEINFO*)singlylinkedlist_item_get_value(list_item);
@@ -614,9 +611,177 @@ BROKER_MODULEINFO* broker_locate_handle(BROKER_HANDLE_DATA* broker_data, MODULE_
     }
     else
     {
-        result = (BROKER_MODULEINFO*)singlylinkedlist_item_get_value(module_info_item);
+result = (BROKER_MODULEINFO*)singlylinkedlist_item_get_value(module_info_item);
     }
     return result;
+}
+
+BROKER_RESULT Broker_AddModule(BROKER_HANDLE broker, const MODULE* module)
+{
+    BROKER_RESULT result;
+
+    /*Codes_SRS_BROKER_99_013: [If `broker` or `module` is NULL the function shall return BROKER_INVALIDARG.]*/
+    if (broker == NULL || module == NULL)
+    {
+        result = BROKER_INVALIDARG;
+        LogError("invalid parameter (NULL).");
+    }
+    /*Codes_SRS_BROKER_99_014: [If `module_handle` or `module_apis` are `NULL` the function shall return `BROKER_INVALIDARG`.]*/
+    else if (module->module_apis == NULL || module->module_handle == NULL)
+    {
+        result = BROKER_INVALIDARG;
+        LogError("invalid parameter (NULL).");
+    }
+    else
+    {
+        BROKER_MODULEINFO* module_info = (BROKER_MODULEINFO*)malloc(sizeof(BROKER_MODULEINFO));
+        if (module_info == NULL)
+        {
+            LogError("Allocate module info failed");
+            result = BROKER_ERROR;
+        }
+        else
+        {
+            module_info->receiverThMsg = NULL;
+            module_info->senderThMsg = NULL;
+            if (init_module(module_info, module) != BROKER_OK)
+            {
+                /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                LogError("start_module failed");
+                free(module_info->module);
+                free(module_info);
+                result = BROKER_ERROR;
+            }
+            else
+            {
+                /*Codes_SRS_BROKER_13_039: [This function shall acquire the lock on BROKER_HANDLE_DATA::modules_lock.]*/
+                BROKER_HANDLE_DATA* broker_data = (BROKER_HANDLE_DATA*)broker;
+                if (Lock(broker_data->modules_lock) != LOCK_OK)
+                {
+                    /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                    LogError("Lock on broker_data->modules_lock failed");
+                    deinit_module(module_info);
+                    free(module_info);
+                    result = BROKER_ERROR;
+                }
+                else
+                {
+                    /*Codes_SRS_BROKER_13_045: [Broker_AddModule shall append the new instance of BROKER_MODULEINFO to BROKER_HANDLE_DATA::modules.]*/
+                    LIST_ITEM_HANDLE moduleListItem = singlylinkedlist_add(broker_data->modules, module_info);
+                    if (moduleListItem == NULL)
+                    {
+                        /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                        LogError("singlylinkedlist_add failed");
+                        deinit_module(module_info);
+                        free(module_info);
+                        result = BROKER_ERROR;
+                    }
+                    else
+                    {
+                        if (start_module(module_info, broker_data->url) != BROKER_OK)
+                        {
+                            LogError("start_module failed");
+                            deinit_module(module_info);
+                            singlylinkedlist_remove(broker_data->modules, moduleListItem);
+                            free(module_info);
+                            result = BROKER_ERROR;
+                        }
+                        else
+                        {
+                            /*Codes_SRS_BROKER_13_047: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                            result = BROKER_OK;
+                        }
+                    }
+
+                    /*Codes_SRS_BROKER_13_046: [This function shall release the lock on BROKER_HANDLE_DATA::modules_lock.]*/
+                    Unlock(broker_data->modules_lock);
+                }
+            }
+
+        }
+    }
+
+    return result;
+}
+
+
+
+static int thread_message_control_receiver_thread_worker(void* context)
+{
+    THREAD_MESSAGE_HANDLING_RECEIVER* receiverContext = (THREAD_MESSAGE_HANDLING_RECEIVER*)context;
+    BROKER_MODULEINFO* receiver_module_info = (BROKER_MODULEINFO*)receiverContext->module_info;
+    while (true) {
+        THREAD_MESSAGE_CTRL* msgCtrl = NULL;
+        if (Lock(receiverContext->lock) != LOCK_OK) {
+            LogError("lock for receiverContext in thread_message_control_receiver_thread_worker failed");
+        }
+        else {
+            if (!receiverContext->toContinue)
+            {
+                if (Unlock(receiverContext->lock) != LOCK_OK) {
+                    LogError("Unlock for receiverContext in thread_message_control_receiver_thread_worker failed");
+                }
+                break;
+            }
+            COND_RESULT cond_result = Condition_Wait(receiverContext->condition, receiverContext->lock, 0);
+            if (cond_result != COND_OK) {
+                LogError("Wait for condition for receiverContext in thread_message_control_receiver_thread_worker failed");
+            }
+            else {
+                THREAD_MESSAGE_CTRL* pre_receive_msg = NULL;
+                THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* sender = receiverContext->senders;
+                while (sender != NULL) {
+                    Lock(sender->sender_module_info->senderThMsg->lock);
+                    THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* current_receiver = sender->sender_module_info->senderThMsg->receivers;
+                    while (current_receiver != NULL) {
+                        if (current_receiver->receiver == receiverContext) {
+                            if (msgCtrl == NULL) {
+                                msgCtrl = current_receiver->sendingMessages;
+                                pre_receive_msg = msgCtrl;
+                            }
+                            else {
+                                pre_receive_msg->next = current_receiver->sendingMessages;
+                                pre_receive_msg = pre_receive_msg->next;
+                            }
+                            THREAD_MESSAGE_CTRL* current_sending_msg = pre_receive_msg;
+                            while (current_sending_msg != NULL) {
+                                if (current_sending_msg->next == NULL) {
+                                    pre_receive_msg = current_sending_msg;
+                                }
+                                current_sending_msg = current_sending_msg->next;
+                            }
+                            current_receiver->sendingMessages = NULL;
+                            break;
+                        }
+                    }
+                    THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* current_sender = sender;
+                    sender = sender->next;
+                    if (Unlock(current_sender->sender_module_info->senderThMsg->lock) != LOCK_OK) {
+                        LogError("Unock for senderThMsg in thread_message_control_receiver_thread_worker failed");
+                    }
+                }
+                if (Unlock(receiverContext->lock) != LOCK_OK) {
+                    LogError("Unlock for receiverContext in thread_message_control_receiver_thread_worker failed");
+                }
+            }
+        }
+        THREAD_MESSAGE_CTRL* current_msg = msgCtrl;
+        while (current_msg != NULL) {
+            MODULE_RECEIVE(receiver_module_info->module->module_apis)(receiver_module_info->module->module_handle, current_msg->msg);
+            ThreadAPI_Sleep(0);
+            THREAD_MESSAGE_CTRL* tmp_msg = current_msg;
+            current_msg = current_msg->next;
+            Message_Destroy(tmp_msg->msg);
+            free((void*)tmp_msg);
+        }
+    }
+
+    Condition_Deinit(receiverContext->condition);
+    if (Lock_Deinit(receiverContext->lock) != LOCK_OK) {
+        LogError("Deinit for receiverContext in thread_message_control_receiver_thread_worker failed");
+    }
+
+    return 0;
 }
 
 BROKER_RESULT Broker_AddLink(BROKER_HANDLE broker, const BROKER_LINK_DATA* link)
@@ -661,17 +826,134 @@ BROKER_RESULT Broker_AddLink(BROKER_HANDLE broker, const BROKER_LINK_DATA* link)
                 }
                 else
                 {
-                    /*Codes_SRS_BROKER_17_032: [ Broker_AddLink shall subscribe module_info->receive_socket to the link->source module handle. ]*/
-                    if (nn_setsockopt(
-                        module_info->receive_socket, NN_SUB, NN_SUB_SUBSCRIBE, &(link->module_source_handle), sizeof(MODULE_HANDLE)) < 0)
-                    {
-                        /*Codes_SRS_BROKER_17_034: [ Upon an error, Broker_AddLink shall return BROKER_ADD_LINK_ERROR ]*/
-                        LogError("Unable to make link in Broker");
-                        result = BROKER_ADD_LINK_ERROR;
+                    if (module_info->module->module_loader_type != OUTPROCESS&&source_module->module->module_loader_type != OUTPROCESS&&link->message_type == BROKER_LINK_MESSAGE_TYPE_THREAD) {
+                        if (module_info->receiverThMsg == NULL) {
+                            module_info->receiverThMsg = (THREAD_MESSAGE_HANDLING_RECEIVER*)malloc(sizeof(THREAD_MESSAGE_HANDLING_RECEIVER));
+                            if (module_info->receiverThMsg == NULL) {
+                                LogError("malloc receiverThMsg in Broker_AddLink failed.");
+                                result = BROKER_ADD_LINK_ERROR;
+                            }
+                            else {
+                                module_info->receiverThMsg->lock = Lock_Init();
+                                module_info->receiverThMsg->condition = Condition_Init();
+                                if (module_info->receiverThMsg->lock == NULL || module_info->receiverThMsg->condition == NULL) {
+                                    LogError("create lock or condition for receiverThMsg in Broker_AddLink failed. - lock:%08x,condition:%08x", module_info->receiverThMsg->lock, module_info->receiverThMsg->condition);
+                                    if (module_info->receiverThMsg->lock != NULL) {
+                                        Lock_Deinit(module_info->receiverThMsg->lock);
+                                    }
+                                    if (module_info->receiverThMsg->condition != NULL) {
+                                        Condition_Deinit(module_info->receiverThMsg->condition);
+                                    }
+                                    free(module_info->receiverThMsg);
+                                    module_info->receiverThMsg = NULL;
+                                    result = BROKER_ADD_LINK_ERROR;
+                                }
+                                else {
+                                    module_info->receiverThMsg->toContinue = true;
+                                    module_info->receiverThMsg->senders = NULL;
+                                    module_info->receiverThMsg->module_info = module_info;
+                                    if (module_info->receiverThMsg->lock == NULL || module_info->receiverThMsg->condition == NULL) {
+                                        LogError("create lock or condition for receiverThMsg in Broker_AddLink failed. - lock:%08x,condition:%08x", module_info->receiverThMsg->lock, module_info->receiverThMsg->condition);
+                                        if (module_info->receiverThMsg->lock != NULL) {
+                                            Lock_Deinit(module_info->receiverThMsg->lock);
+                                        }
+                                        if (module_info->receiverThMsg->condition != NULL) {
+                                            Condition_Deinit(module_info->receiverThMsg->condition);
+                                        }
+                                        free(module_info->receiverThMsg);
+                                        module_info->receiverThMsg = NULL;
+                                        result = BROKER_ADD_LINK_ERROR;
+                                    }
+                                    else {
+                                        ThreadAPI_Create(&(module_info->receiverThMsg->receiver_thread), thread_message_control_receiver_thread_worker, module_info->receiverThMsg);
+                                    }
+                                }
+                            }
+                        }
+                        THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* current_sender = module_info->receiverThMsg->senders;
+                        THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* pre_sender = NULL;
+                        while (current_sender != NULL) {
+                            pre_sender = current_sender;
+                            current_sender = current_sender->next;
+                        }
+                        if (current_sender == NULL) {
+                            current_sender = (THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER*)malloc(sizeof(THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER));
+                            if (current_sender == NULL) {
+                                LogError("malloc current_sender in Broker_AddLink failed.");
+                                result = BROKER_ADD_LINK_ERROR;
+                            }
+                            else {
+                                current_sender->next = NULL;
+                                current_sender->sender_module_info = source_module;
+                                if (pre_sender == NULL) {
+                                    module_info->receiverThMsg->senders = current_sender;
+                                }
+                                else {
+                                    pre_sender->next = current_sender;
+                                }
+                            }
+                        }
+                        if (source_module->senderThMsg == NULL) {
+                            source_module->senderThMsg = (THREAD_MESSAGE_HANDLING_SENDER*)malloc(sizeof(THREAD_MESSAGE_HANDLING_SENDER));
+                            if (source_module->senderThMsg == NULL) {
+                                LogError("malloc senderThMsg in Broker_AddLink failed.");
+                                result = BROKER_ADD_LINK_ERROR;
+                            }
+                            else {
+                                source_module->senderThMsg->lock = Lock_Init();
+                                if (source_module->senderThMsg->lock == NULL) {
+                                    LogError("");
+                                    free(source_module->senderThMsg);
+                                    source_module->senderThMsg = NULL;
+                                    result = BROKER_ADD_LINK_ERROR;
+                                }
+                                else {
+                                    source_module->senderThMsg->receivers = NULL;
+                                }
+                            }
+                        }
+                        if (source_module->senderThMsg != NULL) {
+                            THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* current_receiver = source_module->senderThMsg->receivers;
+                            THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* pre_receiver = NULL;
+                            while (current_receiver != NULL) {
+                                pre_receiver = current_receiver;
+                                current_receiver = current_receiver->next;
+                            }
+                            if (current_receiver == NULL) {
+                                current_receiver = (THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER*)malloc(sizeof(THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER));
+                                if (current_receiver == NULL) {
+                                    LogError("malloc current_receiver in Broker_AddLink failed.");
+                                    result = BROKER_ADD_LINK_ERROR;
+                                }
+                                else {
+                                    current_receiver->next = NULL;
+                                    current_receiver->receiver = module_info->receiverThMsg;
+                                    current_receiver->sendingMessages = NULL;
+                                    if (pre_receiver == NULL) {
+                                        source_module->senderThMsg->receivers = current_receiver;
+                                    }
+                                    else {
+                                        pre_receiver->next = current_receiver;
+                                    }
+                                    result = BROKER_OK;
+                                }
+                            }
+                        }
                     }
-                    else
-                    {
-                        result = BROKER_OK;
+                    else {
+                        // in the case of out process module then should be done next step!! TODO:
+                        /*Codes_SRS_BROKER_17_032: [ Broker_AddLink shall subscribe module_info->receive_socket to the link->source module handle. ]*/
+                        if (nn_setsockopt(
+                            module_info->receive_socket, NN_SUB, NN_SUB_SUBSCRIBE, &(link->module_source_handle), sizeof(MODULE_HANDLE)) < 0)
+                        {
+                            /*Codes_SRS_BROKER_17_034: [ Upon an error, Broker_AddLink shall return BROKER_ADD_LINK_ERROR ]*/
+                            LogError("Unable to make link in Broker");
+                            result = BROKER_ADD_LINK_ERROR;
+                        }
+                        else
+                        {
+                            result = BROKER_OK;
+                        }
                     }
                 }
             }
@@ -724,16 +1006,74 @@ BROKER_RESULT Broker_RemoveLink(BROKER_HANDLE broker, const BROKER_LINK_DATA* li
                 else
                 {
                     /*Codes_SRS_BROKER_17_038: [ Broker_RemoveLink shall unsubscribe module_info->receive_socket from the link->module_source_handle module handle. ]*/
-                    if (nn_setsockopt(
-                        module_info->receive_socket, NN_SUB, NN_SUB_UNSUBSCRIBE, &(link->module_source_handle), sizeof(MODULE_HANDLE)) < 0)
-                    {
-                        /*Codes_SRS_BROKER_17_040: [ Upon an error, Broker_RemoveLink shall return BROKER_REMOVE_LINK_ERROR. ]*/
-                        LogError("Unable to make link in Broker");
-                        result = BROKER_REMOVE_LINK_ERROR;
+//                    if (nn_setsockopt(
+//                      module_info->receive_socket, NN_SUB, NN_SUB_UNSUBSCRIBE, &(link->module_source_handle), sizeof(MODULE_HANDLE)) < 0)
+//                  {
+//                      /*Codes_SRS_BROKER_17_040: [ Upon an error, Broker_RemoveLink shall return BROKER_REMOVE_LINK_ERROR. ]*/
+//                      LogError("Unable to make link in Broker");
+//                      result = BROKER_REMOVE_LINK_ERROR;
+//                  }
+//                  else
+//                  {
+//                      result = BROKER_OK;
+//                  }
+                    if (module_info->receiverThMsg != NULL&&source_module_info->senderThMsg != NULL) {
+                        Lock(module_info->receiverThMsg->lock);
+                        THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* sender = module_info->receiverThMsg->senders;
+                        THREAD_MESSAGE_HANDLING_SENDER_FOR_RECEIVER* pre_sender = NULL;
+                        while (sender != NULL) {
+                            if (sender->sender_module_info == source_module_info) {
+                                if (pre_sender == NULL) {
+                                    module_info->receiverThMsg->senders = sender->next;
+                                }
+                                else {
+                                    pre_sender->next = sender->next;
+                                }
+                                break;
+                            }
+                            pre_sender = sender;
+                            sender = sender->next;
+                        }
+                        Unlock(module_info->receiverThMsg->lock);
+
+                        Lock(source_module_info->senderThMsg->lock);
+                        THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* receiver = source_module_info->senderThMsg->receivers;
+                        THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* pre_receiver = NULL;
+                        while (receiver!=NULL)
+                        {
+                            if (receiver->receiver->module_info == module_info) {
+                                if (pre_receiver != NULL) {
+                                    pre_receiver->next = receiver->next;
+                                }
+                                else {
+                                    source_module_info->senderThMsg->receivers = receiver->next;
+                                }
+                                break;
+                            }
+                            pre_receiver = receiver;
+                            receiver = receiver->next;
+                        }
+                        if (receiver != NULL&&sender != NULL) {
+                            free((void*)sender);
+
+                            THREAD_MESSAGE_CTRL* sendingMsg = receiver->sendingMessages;
+                            while (sendingMsg != NULL) {
+                                THREAD_MESSAGE_CTRL* next = sendingMsg->next;
+                                Message_Destroy(sendingMsg->msg);
+                                free((void*)sendingMsg);
+                                sendingMsg = next;
+                            }
+                            free((void*)receiver);
+                            result = BROKER_OK;
+                        }
+                        else {
+                            // may be error but shoudn't be system error
+                            result = BROKER_REMOVE_LINK_ERROR;
+                        }
+                        Unlock(source_module_info->senderThMsg->lock);
                     }
-                    else
-                    {
-                        result = BROKER_OK;
+                    else {
+                        // error
                     }
                 }
             }
@@ -785,12 +1125,13 @@ extern void Broker_DecRef(BROKER_HANDLE broker)
 
 BROKER_RESULT Broker_Publish(BROKER_HANDLE broker, MODULE_HANDLE source, MESSAGE_HANDLE message)
 {
-    BROKER_RESULT result;
+    BROKER_RESULT result = BROKER_OK;
     /*Codes_SRS_BROKER_13_030: [If broker or message is NULL the function shall return BROKER_INVALIDARG.]*/
     if (broker == NULL || source == NULL || message == NULL)
     {
         result = BROKER_INVALIDARG;
         LogError("Broker handle, source, and/or message handle is NULL");
+        return result;
     }
     else
     {
@@ -801,66 +1142,121 @@ BROKER_RESULT Broker_Publish(BROKER_HANDLE broker, MODULE_HANDLE source, MESSAGE
             /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
             LogError("Lock on broker_data->modules_lock failed");
             result = BROKER_ERROR;
+            return result;
         }
         else
         {
-            int32_t msg_size;
-            int32_t buf_size;
-            /*Codes_SRS_BROKER_17_007: [ Broker_Publish shall clone the message. ]*/
-            MESSAGE_HANDLE msg = Message_Clone(message);
-            /*Codes_SRS_BROKER_17_008: [ Broker_Publish shall serialize the message. ]*/
-            msg_size = Message_ToByteArray(message, NULL, 0);
-            if (msg_size < 0)
-            {
-                /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                LogError("unable to serialize a message [%p]", msg);
-                Message_Destroy(msg);
+            BROKER_MODULEINFO* source_info = broker_locate_handle(broker_data, source);
+            if (source_info == NULL) {
+                LogError("Can't find BROKER_MODULEINFO");
                 result = BROKER_ERROR;
+                return result;
             }
-            else
-            {
-                /*Codes_SRS_BROKER_17_025: [ Broker_Publish shall allocate a nanomsg buffer the size of the serialized message + sizeof(MODULE_HANDLE). ]*/
-                buf_size = msg_size + sizeof(MODULE_HANDLE);
-                void* nn_msg = nn_allocmsg(buf_size, 0);
-                if (nn_msg == NULL)
+            bool normalMessaging = true;
+            if (source_info->senderThMsg != NULL) {
+                // TODO: current version is not support nanomsg and thread messaging.
+                Lock(source_info->senderThMsg->lock);
+                THREAD_MESSAGE_HANDLING_RECIEVERS_IN_SENDER* target_receiver = source_info->senderThMsg->receivers;
+                while (target_receiver != NULL) {
+                    THREAD_MESSAGE_CTRL* current_msg = (THREAD_MESSAGE_CTRL*)malloc(sizeof(THREAD_MESSAGE_CTRL));
+                    if (current_msg == NULL) {
+                        LogError("malloc current_msg in Broker_Publish failed.");
+                    }
+                    else {
+                        current_msg->next = NULL;
+                        current_msg->msg = Message_Clone(message);
+                        if (current_msg->msg == NULL) {
+                            LogError("clone message in Broker_Publish failed.");
+                            free(current_msg);
+                        }
+                        else {
+                            THREAD_MESSAGE_CTRL* last_msg = target_receiver->sendingMessages;
+                            if (last_msg == NULL) {
+                                target_receiver->sendingMessages = current_msg;
+                            }
+                            else {
+                                while (last_msg->next != NULL)
+                                {
+                                    last_msg = last_msg->next;
+                                }
+                                last_msg->next = current_msg;
+                            }
+                            Condition_Post(target_receiver->receiver->condition);
+                            target_receiver = target_receiver->next;
+                        }
+                    }
+                }
+                if (Unlock(source_info->senderThMsg->lock) != LOCK_OK) {
+                    LogError("unlock senderThMsg in Broker_Publish failed.");
+                }
+
+                normalMessaging = false;
+                result = BROKER_OK;
+            }
+
+            if (normalMessaging) {
+                int32_t msg_size;
+                /*Codes_SRS_BROKER_17_007: [ Broker_Publish shall clone the message. ]*/
+                MESSAGE_HANDLE msg = Message_Clone(message);
+                /*Codes_SRS_BROKER_17_008: [ Broker_Publish shall serialize the message. ]*/
+                msg_size = Message_ToByteArray(message, NULL, 0);
+                if (msg_size < 0)
                 {
                     /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
                     LogError("unable to serialize a message [%p]", msg);
+                    Message_Destroy(msg);
                     result = BROKER_ERROR;
                 }
                 else
                 {
-                    /*Codes_SRS_BROKER_17_026: [ Broker_Publish shall copy source into the beginning of the nanomsg buffer. ]*/
-                    unsigned char *nn_msg_bytes = (unsigned char *)nn_msg;
-                    memcpy(nn_msg_bytes, &source, sizeof(MODULE_HANDLE));
-                    /*Codes_SRS_BROKER_17_027: [ Broker_Publish shall serialize the message into the remainder of the nanomsg buffer. ]*/
-                    nn_msg_bytes += sizeof(MODULE_HANDLE);
-                    Message_ToByteArray(message, nn_msg_bytes, msg_size);
+                    time_t current = time(NULL);
 
-                    /*Codes_SRS_BROKER_17_010: [ Broker_Publish shall send a message on the publish_socket. ]*/
-                    int nbytes = nn_send(broker_data->publish_socket, &nn_msg, NN_MSG, 0);
-                    if (nbytes != buf_size)
-                    {
-                        /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
-                        LogError("unable to send a message [%p]", msg);
-                        /*Codes_SRS_BROKER_17_012: [ Broker_Publish shall free the message. ]*/
-                        nn_freemsg(nn_msg);
-                        result = BROKER_ERROR;
-                    }
-                    else
-                    {
-                        result = BROKER_OK;
-                    }
+                        int32_t buf_size;
+                        /*Codes_SRS_BROKER_17_025: [ Broker_Publish shall allocate a nanomsg buffer the size of the serialized message + sizeof(MODULE_HANDLE). ]*/
+                        buf_size = msg_size + sizeof(MODULE_HANDLE) + sizeof(int32_t);
+                            buf_size += sizeof(int32_t);
+                        void* nn_msg = nn_allocmsg(buf_size, 0);
+                        if (nn_msg == NULL)
+                        {
+                            /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                            LogError("unable to serialize a message [%p]", msg);
+                            result = BROKER_ERROR;
+                        }
+                        else
+                        {
+                            /*Codes_SRS_BROKER_17_026: [ Broker_Publish shall copy source into the beginning of the nanomsg buffer. ]*/
+                            unsigned char *nn_msg_bytes = (unsigned char *)nn_msg;
+                            memcpy(nn_msg_bytes, &source, sizeof(MODULE_HANDLE));
+                            /*Codes_SRS_BROKER_17_027: [ Broker_Publish shall serialize the message into the remainder of the nanomsg buffer. ]*/
+                            nn_msg_bytes += sizeof(MODULE_HANDLE);
+                            nn_msg_bytes += sizeof(int32_t);
+                                *((int32_t*)nn_msg_bytes) = msg_size;
+                                nn_msg_bytes += sizeof(int32_t);
+                                Message_ToByteArray(message, nn_msg_bytes, msg_size);
+                                result = BROKER_OK;
+
+                            /*Codes_SRS_BROKER_17_010: [ Broker_Publish shall send a message on the publish_socket. ]*/
+                            int nbytes = nn_send(broker_data->publish_socket, &nn_msg, NN_MSG, 0);
+                            if (nbytes != buf_size)
+                            {
+                                /*Codes_SRS_BROKER_13_053: [This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise.]*/
+                                LogError("unable to send a message [%p]", msg);
+                                /*Codes_SRS_BROKER_17_012: [ Broker_Publish shall free the message. ]*/
+                                nn_freemsg(nn_msg);
+                                result = BROKER_ERROR;
+                            }
+                        }
+                    /*Codes_SRS_BROKER_17_012: [ Broker_Publish shall free the message. ]*/
+                    Message_Destroy(msg);
+                    /*Codes_SRS_BROKER_17_011: [ Broker_Publish shall free the serialized message data. ]*/
                 }
-                /*Codes_SRS_BROKER_17_012: [ Broker_Publish shall free the message. ]*/
-                Message_Destroy(msg);
-                /*Codes_SRS_BROKER_17_011: [ Broker_Publish shall free the serialized message data. ]*/
+
             }
             /*Codes_SRS_BROKER_17_023: [ Broker_Publish shall Unlock the modules lock. ]*/
             Unlock(broker_data->modules_lock);
         }
-
     }
     /*Codes_SRS_BROKER_13_037: [ This function shall return BROKER_ERROR if an underlying API call to the platform causes an error or BROKER_OK otherwise. ]*/
     return result;
 }
+

--- a/v1/core/src/gateway_createfromjson.c
+++ b/v1/core/src/gateway_createfromjson.c
@@ -24,6 +24,7 @@
 #define LINKS_KEY "links"
 #define SOURCE_KEY "source"
 #define SINK_KEY "sink"
+#define LINK_MSGTYPE_KEY "message.type"
 
 #define PARSE_JSON_RESULT_VALUES \
     PARSE_JSON_SUCCESS, \
@@ -555,6 +556,7 @@ static PARSE_JSON_RESULT parse_json_internal(GATEWAY_PROPERTIES* out_properties,
                                 route = json_array_get_object(links_array, links_index);
                                 const char* module_source = json_object_get_string(route, SOURCE_KEY);
                                 const char* module_sink = json_object_get_string(route, SINK_KEY);
+                                const char* message_type = json_object_get_string(route, LINK_MSGTYPE_KEY);
 
                                 if (module_source != NULL && module_sink != NULL)
                                 {
@@ -562,6 +564,12 @@ static PARSE_JSON_RESULT parse_json_internal(GATEWAY_PROPERTIES* out_properties,
                                         module_source,
                                         module_sink
                                     };
+                                    if (message_type != NULL&&strcmp(message_type, "thread-message") == 0) {
+                                        entry.message_type = GATEWAY_LINK_ENTRY_MESSAGE_TYPE_THREAD;
+                                    }
+                                    else {
+                                        entry.message_type = GATEWAY_LINK_ENTRY_MESSAGE_TYPE_DEFAULT;
+                                    }
 
                                     /* Codes_SRS_GATEWAY_JSON_04_002: [ The function shall add all modules source and sink to GATEWAY_PROPERTIES inside gateway_links. ] */
                                     if (VECTOR_push_back(out_properties->gateway_links, &entry, 1) == 0)


### PR DESCRIPTION
Current broker runtime uses nanomsg as messaging mechanism but nanomsg causes many messages lost because it uses pub/sub mode.
Worst case, 40-50% messages have been lost.
I add thread messaging mechanism for communication between two modules by add-link specification in JSON configuration. 
When user specifies following in JSON configuration...
"links":[
 { "source":"SensorTag", "sink":"mapping", "message-type":"thread-message" }
And both source and sink are loaded as in-process then broker use not nanomsg but thread messaging mechanism.

