### PR TITLE
Print out a helpful message when a submodule fails to build

### DIFF
--- a/v1/gatewayFunctions.cmake
+++ b/v1/gatewayFunctions.cmake
@@ -154,7 +154,7 @@ function(findAndInstall libraryName version submoduleRootDirectory cmakeRootDire
                 RESULT_VARIABLE res
             )
             if(${res})
-                message(FATAL_ERROR "Error running cmake for ${libraryName}: ${res}")
+                message(FATAL_ERROR "ERROR running cmake for ${libraryName}: ${res}")
             endif()
 
             # Install library
@@ -167,7 +167,9 @@ function(findAndInstall libraryName version submoduleRootDirectory cmakeRootDire
                 ERROR_FILE error.txt
             )
             if(${res})
-                message(FATAL_ERROR "Error installing ${libraryName}: ${res}")
+                message(FATAL_ERROR "**ERROR installing ${libraryName}. See "
+                    "${cmakeRootDirectory}/build/error.txt and "
+                    "${cmakeRootDirectory}/build/output.txt.\n")
             endif()
 
             #Attempt to find library with the REQUIRED option

--- a/v1/gatewayFunctions.cmake
+++ b/v1/gatewayFunctions.cmake
@@ -32,7 +32,7 @@ function(findAndInstallNonFindPkg libraryName submoduleRootDirectory cmakeRootDi
             )
         endif()
         if(${res})
-            message(FATAL_ERROR "Error pull submodules: ${res}")
+            message(FATAL_ERROR "Error pulling submodules: ${res}")
         endif()
 
         #Create the build directory to run cmake, and run cmake
@@ -80,7 +80,9 @@ function(findAndInstallNonFindPkg libraryName submoduleRootDirectory cmakeRootDi
             ERROR_FILE error.txt
         )
         if(${res})
-            message(FATAL_ERROR "Error installing ${libraryName}: ${res}")
+            message(FATAL_ERROR "**ERROR installing ${libraryName}. See "
+                "${cmakeRootDirectory}/build/error.txt and "
+                "${cmakeRootDirectory}/build/output.txt.\n")
         endif()
     endif()
 endfunction()
@@ -154,7 +156,7 @@ function(findAndInstall libraryName version submoduleRootDirectory cmakeRootDire
                 RESULT_VARIABLE res
             )
             if(${res})
-                message(FATAL_ERROR "ERROR running cmake for ${libraryName}: ${res}")
+                message(FATAL_ERROR "Error running cmake for ${libraryName}: ${res}")
             endif()
 
             # Install library


### PR DESCRIPTION
We frequently ask people to send us log files from rather obscure locations when one of our submodules fails to build. This change adds some useful information to the error message, directing the user to the right log files. It might help people figure out what's wrong without having to open a GitHub issue.