### PR TITLE
Replace non-ascii characters

### DIFF
--- a/v1/README.md
+++ b/v1/README.md
@@ -5,9 +5,9 @@ V1 will continue to be supported. V1 documentation which used to live on docs.mi
 
 
 # 5/10/2017
-The Azure IoT Gateway SDK was our first step to enabling edge analytics in IoT solutions. We’re doubling down on, and expanding, this vision as explained in Satya’s Keynote at the Build conference and Sam George’s [blog post](http://blogs.microsoft.com/iot/?p=23040). As part of this evolution, the SDK is becoming an extensible product you can use instead of a set of code you build. To reflect this, we’re changing the name to Azure IoT Edge.
+The Azure IoT Gateway SDK was our first step to enabling edge analytics in IoT solutions. We're doubling down on, and expanding, this vision as explained in Satya's Keynote at the Build conference and Sam George's [blog post](http://blogs.microsoft.com/iot/?p=23040). As part of this evolution, the SDK is becoming an extensible product you can use instead of a set of code you build. To reflect this, we're changing the name to Azure IoT Edge.
 
-All the important developer concepts are maintained as we continue to improve Azure IoT Edge. Specifically…
+All the important developer concepts are maintained as we continue to improve Azure IoT Edge. Specifically:
 -	modules remain units compute which can be written in your programming language of choice.
 -	traditional cloud services and 3rd party business logic can run as a module.
 -	modules can communicate with each other via declarative message passing.
@@ -51,8 +51,8 @@ The following modules are available in this repository:
 
 ## Create Modules using Packages
 The fastest way to setup your development environment to start writing modules is to leverage our packages for Java, C#, and Node.js. Our [sample apps repo](https://github.com/Azure-Samples/iot-edge-samples) has quick steps on getting started with these packages:
-- [Azure IoT Edge Maven](https://mvnrepository.com/artifact/com.microsoft.azure.gateway/gateway-module-base): With this you will be able to run the Azure IoT Edge sample app and start writing Java modules. This package contains the Azure IoT Edge core and links to the module dependencies’ packages for Linux or Windows. Requires the [java binding package](https://mvnrepository.com/artifact/com.microsoft.azure.gateway/gateway-java-binding).  
-- [Azure IoT Edge npm](https://www.npmjs.com/package/azure-iot-gateway): With this you will be able to run the Azure IoT Edge sample app and start writing Node.js modules. This package contains the Azure IoT Edge core and auto-installs the module dependencies’ packages for Linux or Windows.
+- [Azure IoT Edge Maven](https://mvnrepository.com/artifact/com.microsoft.azure.gateway/gateway-module-base): With this you will be able to run the Azure IoT Edge sample app and start writing Java modules. This package contains the Azure IoT Edge core and links to the module dependencies' packages for Linux or Windows. Requires the [java binding package](https://mvnrepository.com/artifact/com.microsoft.azure.gateway/gateway-java-binding).  
+- [Azure IoT Edge npm](https://www.npmjs.com/package/azure-iot-gateway): With this you will be able to run the Azure IoT Edge sample app and start writing Node.js modules. This package contains the Azure IoT Edge core and auto-installs the module dependencies' packages for Linux or Windows.
 - [Azure IoT Edge NuGet .NET Standard](https://www.nuget.org/packages/Microsoft.Azure.Devices.Gateway.Module.NetStandard/): With this you will be able to run the Azure IoT Edge sample app and write .NET Standard modules on Windows ([IoT Edge Core for Windows](https://www.nuget.org/packages/Microsoft.Azure.Devices.Gateway.Native.Windows.x64/)) or Ubuntu ([IoT Edge Core for Ubuntu](https://www.nuget.org/packages/Microsoft.Azure.Devices.Gateway.Native.Ubuntu.x64/)).
 - [Azure IoT Edge NuGet .NET Framework](https://www.nuget.org/packages/Microsoft.Azure.IoT.Gateway.Module): With this you will be able to run the Azure IoT Edge sample app and write .NET Framework modules on Windows, dependent on [IoT Edge Core for Windows](https://www.nuget.org/packages/Microsoft.Azure.Devices.Gateway.Native.Windows.x64/).
 
@@ -65,9 +65,9 @@ a module to find out how to get it, who supports it, etc.
 >| OPC Proxy         | https://github.com/Azure/iot-edge-opc-proxy                    | 2017-04-27               |
 >| Modbus            | https://github.com/Azure/iot-gateway-modbus                    | 2017-01-13               |
 >| GZip Compression  | https://github.com/Azure/iot-gateway-compression-gzip-nodejs   | 2016-12-16               |
->| Proficy Historian | https://github.com/Azure-Samples/iot-edge-proficy-historian    | 2017-04-27               |
->| SQLite            | https://github.com/Azure/iot-gateway-sqlite                    | 2017-01-13               |
->| Batch/Shred       | https://github.com/Azure/iot-gateway-batch-nodejs              | 2017-01-13               |
+>| Proficy Historian | https://github.com/Azure-Samples/iot-edge-proficy-historian    | 2017-04-27               |
+>| SQLite            | https://github.com/Azure/iot-gateway-sqlite                    | 2017-01-13               |
+>| Batch/Shred       | https://github.com/Azure/iot-gateway-batch-nodejs              | 2017-01-13               |
 >| ZWave             | https://github.com/MaxKhlupnov/SmartHive                       | 2017-04-27               | 
 
 We'd love to feature your module here! See our [Contribution guidelines](Contributing.md) for 

--- a/v1/ThirdPartyNotices.txt
+++ b/v1/ThirdPartyNotices.txt
@@ -1,5 +1,5 @@
 Third Party Notices for the Azure IoT Edge Project
-This Microsoft Open Source project is based on or incorporates material from the project(s) listed below (�Third Party OSS�). The original copyright notice and the license under which Microsoft received such Third Party OSS, are set forth below.  Such licenses and notices are provided for informational purposes only.  Microsoft licenses the Third Party OSS to you under the licensing terms for the Microsoft product or service.  Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
+This Microsoft Open Source project is based on or incorporates material from the project(s) listed below ("Third Party OSS"). The original copyright notice and the license under which Microsoft received such Third Party OSS, are set forth below.  Such licenses and notices are provided for informational purposes only.  Microsoft licenses the Third Party OSS to you under the licensing terms for the Microsoft product or service.  Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
 #SensorTag (http://processors.wiki.ti.com/index.php/CC2650_SensorTag_User's_Guide#Data)
 Creative Commons Attribution-ShareAlike 3.0
 THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
@@ -51,7 +51,7 @@ Microsoft Corporation
 One Microsoft Way
 Redmond, WA 98052 USA
  
-Please write �source for [Third Party IP]� in the memo line of your payment. 
+Please write "source for [Third Party IP]" in the memo line of your payment. 
   -------------------------
 #GDBus-Glib D-Bus (https://developer.gnome.org/glib/stable/glib.html) 
 GNU Lesser General Public License

--- a/v1/bindings/dotnet/devdoc/dotnet_binding_hld.md
+++ b/v1/bindings/dotnet/devdoc/dotnet_binding_hld.md
@@ -59,7 +59,7 @@ The JSON configuration for .NET Module will be similar to the configuration for 
 ##Native methods description
 ### Module\_Create
 
-When the **.NET Module Host**’s `Module_Create` function is invoked by the
+When the **.NET Module Host**'s `Module_Create` function is invoked by the
 gateway process, it:
 
 -   Creates a CLR instance; 
@@ -68,7 +68,7 @@ gateway process, it:
 
 ### Module\_Start
 
-When the **.NET Module Host**’s `Module_Start` function is invoked by the
+When the **.NET Module Host**'s `Module_Start` function is invoked by the
 gateway, it:
 
 - Checks to see if the .NET module has implemented the `Start` method.
@@ -76,14 +76,14 @@ gateway, it:
 
 ### Module\_Receive
 
-When the **.NET Module Host**’s `Module_Receive` function is invoked by the
+When the **.NET Module Host**'s `Module_Receive` function is invoked by the
 gateway process, it:
 
 -   Serializes (by calling `Message_ToByteArray` the message content and properties and invokes the `Receive` method implemented by the .NET module (`IGatewayInterface` below). The .NET module will deserialize this byte_array into a Message object.
 
 ### Module\_Destroy
 
-When the **.NET Module Host**’s `Module_Destroy` function is invoked by the
+When the **.NET Module Host**'s `Module_Destroy` function is invoked by the
 gateway, it:
 
 -   Releases resources allocated and calls the `Destroy` method implemented by the .NET Module.

--- a/v1/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
+++ b/v1/bindings/dotnet/dotnet-binding/PrinterModule/DotNetPrinterModule.cs
@@ -24,15 +24,15 @@ namespace PrinterModule
 
         public void Receive(Message received_message)
         {
-            if (received_message != null)
+            if (received_message != null)
             {
-                string messageData = System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length);
-                Console.WriteLine("{0}> Printer module received message: {1}", DateTime.Now.ToLocalTime(), messageData);
+                string messageData = System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length);
+                Console.WriteLine("{0}> Printer module received message: {1}", DateTime.Now.ToLocalTime(), messageData);
  
-                int propCount = 0;
-                foreach (var prop in received_message.Properties)
+                int propCount = 0;
+                foreach (var prop in received_message.Properties)
                 {
-                    Console.WriteLine("\tProperty[{0}]> Key={1} : Value={2}", propCount++, prop.Key, prop.Value);
+                    Console.WriteLine("\tProperty[{0}]> Key={1} : Value={2}", propCount++, prop.Key, prop.Value);
                 }
             }
         }

--- a/v1/bindings/dotnetcore/devdoc/dotnet_core_binding_hld.md
+++ b/v1/bindings/dotnetcore/devdoc/dotnet_core_binding_hld.md
@@ -85,7 +85,7 @@ The JSON configuration for [.NET Core](https://github.com/dotnet/)  Module will 
 ##Native methods description
 ### Module\_Create
 
-When the **.NET Core Module Host**’s `Module_Create` function is invoked by the
+When the **.NET Core Module Host**'s `Module_Create` function is invoked by the
 gateway process, it:
 
 -  Checks if delegates have been created. 
@@ -100,7 +100,7 @@ gateway process, it:
 
 ### Module\_Start
 
-When the **.NET Core Module Host**’s `Module_Start` function is invoked by the
+When the **.NET Core Module Host**'s `Module_Start` function is invoked by the
 gateway, it:
 
 - Call the `Start` Delegate;
@@ -109,7 +109,7 @@ gateway, it:
 
 ### Module\_Receive
 
-When the **.NET Core Module Host**’s `Module_Receive` function is invoked by the
+When the **.NET Core Module Host**'s `Module_Receive` function is invoked by the
 gateway process, it:
 
 - Serializes (by calling `Message_ToByteArray`) the message content and properties and invokes the `Receive` method implemented by the .NET module (`IGatewayInterface` below). The .NET module will deserialize this byte array into a Message object.
@@ -117,7 +117,7 @@ gateway process, it:
 
 ### Module\_Destroy
 
-When the **.NET Module Host**’s `Module_Destroy` function is invoked by the
+When the **.NET Module Host**'s `Module_Destroy` function is invoked by the
 gateway, it:
 
 - Calls the `Destroy` delegate (which is going to call `Destroy` method implemented by the [.NET Core](https://github.com/dotnet/)  Module); 

--- a/v1/bindings/java/devdoc/java_binding_hld.md
+++ b/v1/bindings/java/devdoc/java_binding_hld.md
@@ -75,8 +75,6 @@ where all necessary Java class files are located, `entrypoint.class.name` is the
 of the class that implements the module code. `entrypoint.jvm.options` is
 a JSON object containing any options to be passed to the JVM upon creation.
 
- 
-
 Gateway Module (Java)
 ---------------------
 
@@ -134,8 +132,6 @@ The implementaion of `IGatewayModule` should save the moduleAddr and broker argu
 To simplify this, the Azure IoT Gateway SDK provides an abstract `GatewayModule` class which implements the `IGatewayModule` interface. Module-implementers
 may extend this abstract class when creating a module. If the module extends the `GatewayModule` class the constructor calls `create` method.
 
- 
-
 Exactly like a standard gateway module written in C, the gateway will handle
 making calls to `Module_Create`, `Module_Start`, `Module_Receive`, and 
 `Module_Destroy`. These three functions are implemented by the **Java Module Host** 
@@ -144,7 +140,7 @@ a description of what the **Java Module Host** will do in each of these cases:
 
 ### Module\_Create
 
-When the **Java Module Host**’s `Module_Create` function is invoked by the
+When the **Java Module Host**'s `Module_Create` function is invoked by the
 gateway, it:
 
 -   Creates a JVM with the provided JVM configuration if this is the first Java
@@ -152,7 +148,7 @@ gateway, it:
 
 -   Constructs a `Broker` Java object using the `BROKER_HANDLE`.
 
--   Finds the module’s class with the name specified by the `entrypoint.class.name`,
+-   Finds the module's class with the name specified by the `entrypoint.class.name`,
     finds the constructor that matches these three arguments: the native `MODULE_HANDLE` address,
     the `Broker` object and the JSON args string for that module and invokes it. 
     If the constructor with three parameters is not found, finds no-argument constructor and invokes it and 
@@ -163,7 +159,7 @@ gateway, it:
 
 ### Module\_Start
 
-When the **Java Module Host**’s `Module_Start` function is invoked by the
+When the **Java Module Host**'s `Module_Start` function is invoked by the
 gateway, it:
 
 -   Attaches the current thread to the JVM
@@ -172,7 +168,7 @@ gateway, it:
 
 ### Module\_Receive
 
-When the **Java Module Host**’s `Module_Receive` function is invoked by the
+When the **Java Module Host**'s `Module_Receive` function is invoked by the
 gateway, it:
 
 -   Serializes the `MESSAGE_HANDLE` content and properties and invokes the
@@ -180,7 +176,7 @@ gateway, it:
 
 ### Module\_Destroy
 
-When the **Java Module Host**’s `Module_Destroy` function is invoked by the
+When the **Java Module Host**'s `Module_Destroy` function is invoked by the
 gateway, it:
 
 -   Attaches the current thread to the JVM

--- a/v1/bindings/nodejs/devdoc/nodejs_binding_hld.md
+++ b/v1/bindings/nodejs/devdoc/nodejs_binding_hld.md
@@ -44,7 +44,7 @@ we modified the source in a fork of the Node.js project. We essentially added an
 additional callback function as a parameter to `node::Start`. The changes that
 have been done to Node.js to enable this can be seen in [this
 commit](https://github.com/avranju/node/commit/fb272256ef7743c9b1882aff39fe7f1685fb7cba).
-With this change in place we are able to intercept Node.js’s event loop in the
+With this change in place we are able to intercept Node.js's event loop in the
 following manner:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -151,7 +151,7 @@ modules will however have their *destroy* callback invoked when it is time for
 them to be unloaded.
 
 The configuration for this module will include the path to the root JavaScript
-file that is to be loaded and run when the module starts up. Here’s a sample
+file that is to be loaded and run when the module starts up. Here's a sample
 configuration provided in JSON syntax:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ json
@@ -177,12 +177,12 @@ implementation and hands off control to it. In the sample above we are using the
 default Node.js loader that the gateway SDK ships with.
 
 The `main.path` property specifies the path to the root JavaScript file that
-should be loaded and `args` is configuration that’s specific to this gateway
+should be loaded and `args` is configuration that's specific to this gateway
 module.
 
 The code on the JavaScript side of the implementation has access to an API
 provided by the module host. It maybe useful to have the interface definitions
-of this API handy while reviewing the work that the module host’s create,
+of this API handy while reviewing the work that the module host's create,
 receive and destroy functions do. The API definition is provided below using
 TypeScript syntax for expository purposes:
 
@@ -240,14 +240,14 @@ following actions:
 -   If this is the first time that this API is being called, then it starts a
     new thread to run the Node.js engine and starts up Node.js.
 
--   It sets up a callback function to be called from Node.js’s event loop.
+-   It sets up a callback function to be called from Node.js's event loop.
 
 -   When event loop callback is invoked, it creates an instance of a proxy
     object for the message broker (conforming to the `Broker` interface defined
     above).
 
 -   If this is the first time that a Node.js module is being loaded, then it
-    adds an object to V8’s global context that implements the
+    adds an object to V8's global context that implements the
     `GatewayModuleHost` interface (defined in the TypeScript snippet above).
     This object is identified using the name `gatewayHost`.
 
@@ -265,7 +265,7 @@ following actions:
     which now has a handle to the JavaScript object that implements
     `GatewayModule`. The module then proceeds to invoke `GatewayModule.create`
     passing the handle to the `Broker` object and the configuration that it has
-    read from the module’s configuration
+    read from the module's configuration
 
 ### Module\_Receive
 
@@ -276,7 +276,7 @@ constructs an object that implements the `Message` interface and invokes
 ### Module\_Destroy
 
 The call to `Module_Destroy` is simply forwarded on to `GatewayModule.destroy`.
-It then removes the module reference from it’s internal list of modules.
+It then removes the module reference from it's internal list of modules.
 
 ### Publishing of messages to the broker
 
@@ -300,7 +300,7 @@ this, the following is proposed:
     module.
 
 2.  We provide a [Yeoman generator](http://yeoman.io/) that allows developers to
-    quickly scaffold out a project that’s pre-configured with a gateway and a
+    quickly scaffold out a project that's pre-configured with a gateway and a
     sample module implementation.
 
 3.  The gateway executable that we package in the NPM module will include

--- a/v1/core/devdoc/dynamic_library_requirements.md
+++ b/v1/core/devdoc/dynamic_library_requirements.md
@@ -1,7 +1,5 @@
 # dynamic_library Requirements
 
-
- 
 ## Overview
 dynamic_library is a wrapper for OS system calls for loading, unloading and 
 finding a symbol in a dynamically linked library.

--- a/v1/core/devdoc/message_broker_requirements.md
+++ b/v1/core/devdoc/message_broker_requirements.md
@@ -29,7 +29,7 @@ typedef struct BROKER_MODULEINFO_TAG
     CONST MODULE_API*        module_api;
     
     /**
-     * Handle to the thread on which this module’s message processing loop is
+     * Handle to the thread on which this module's message processing loop is
      * running.
      */
     THREAD_HANDLE           thread;

--- a/v1/core/devdoc/module_loaders.md
+++ b/v1/core/devdoc/module_loaders.md
@@ -28,7 +28,7 @@ loaded and initialized first.
 
 From the perspective of the gateway, a module loader is a piece of code that
 knows how to load a module instance and hand the gateway a table of function
-pointers used to control it. The gateway doesn’t really care how the module
+pointers used to control it. The gateway doesn't really care how the module
 loader goes about acquiring the said pointers.
 
 Loader Configuration
@@ -109,7 +109,7 @@ referenced using the following loader names:
 
 It is legal to completely omit specifying the `loaders` array in which case the
 default loaders specified above will be made available using default options.
-Here’s an example of a module configuration that makes use of the Java loader:
+Here's an example of a module configuration that makes use of the Java loader:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c
 {
@@ -188,7 +188,7 @@ extern const MODULE_LOADER *DynamicLoader_Get(void);
 The gateway, during initialization, creates and populates a vector of
 `MODULE_LOADER` instances so that it has a default set of module loaders to work
 with. As discussed before, the gateway SDK, depending on build options used will
-ship with a set of pre-defined loaders. Here’s an example how this
+ship with a set of pre-defined loaders. Here's an example how this
 initialization code might look like:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ c
@@ -229,14 +229,14 @@ work is given below:
     the gateway as described in the previous section.
 
 2.  Inspect the gateway configuration and create custom loaders. When
-    initializing from JSON, if a loader’s name matches the name of an existing
-    loader then it has the effect of replacing the loader’s configuration. New
-    loaders are added to the gateway’s loaders list (the loader’s function
+    initializing from JSON, if a loader's name matches the name of an existing
+    loader then it has the effect of replacing the loader's configuration. New
+    loaders are added to the gateway's loaders list (the loader's function
     pointer table is copied over from the corresponding *default* loader with
     the same loader type).
 
-3.  When initializing from JSON, each loader’s configuration is parsed by
-    invoking the `ParseConfigurationFromJson` function from the loader’s API.
+3.  When initializing from JSON, each loader's configuration is parsed by
+    invoking the `ParseConfigurationFromJson` function from the loader's API.
 
 ### Loading Modules
 
@@ -245,28 +245,28 @@ The process of loading a given gateway module is described below:
 ![Loading Module Sequence](./media/module_loader_create.png)
 
 1.  When initializing the gateway from JSON, it first attempts to parse the
-    module’s entrypoint data by calling the loader’s `ParseEntryPointFromJson`
+    module's entrypoint data by calling the loader's `ParseEntryPointFromJson`
     function.
 
-2.  It then proceeds to load the module by invoking the loader’s `Load` function
+2.  It then proceeds to load the module by invoking the loader's `Load` function
     passing in the entrypoint it acquired in the previous step. Each loader is
     free to do what it needs to in order to load the module. The native loader
     for example will inspect the entrypoint to retrieve the path to the DLL/SO
     that implements the module and loads it into memory. A language binding
-    module’s loader on the other hand might choose to load the binding module
-    implementation and it’s associated runtime and defer the loading of the
+    module's loader on the other hand might choose to load the binding module
+    implementation and it's associated runtime and defer the loading of the
     actual module code till the time when `Module_Create` is called on the
     binding module.
 
-3.  Next, when the gateway is loaded from JSON, the module’s `args` JSON is
-    parsed by invoking `ParseConfigurationFromJson` on the module’s API.
+3.  Next, when the gateway is loaded from JSON, the module's `args` JSON is
+    parsed by invoking `ParseConfigurationFromJson` on the module's API.
 
-4.  Language binding modules expect a configuration structure that’s typically
-    an amalgamation of the entrypoint data and the module loader’s
+4.  Language binding modules expect a configuration structure that's typically
+    an amalgamation of the entrypoint data and the module loader's
     configuration. In order to provide language binding modules an opportunity
     to perform this merging of configuration information, the loader is expected
     to implement the `BuildModuleConfiguration` function. This function is
-    provided with pointers to the entrypoint data and the module loader’s
+    provided with pointers to the entrypoint data and the module loader's
     configuration and it returns a pointer to a merged variant of the
     configuration as expected by the binding module.
 

--- a/v1/core/devdoc/module_loading_hld.md
+++ b/v1/core/devdoc/module_loading_hld.md
@@ -93,11 +93,11 @@ needs to implement all the functions in the `MODULE_LOADER_API` structure:
 typedef struct MODULE_LOADER_API
 {
     /** @brief Load function, loads module for gateway, returns a valid handle on success */    
-    MODULE_LIBRARY_HANDLE (*Load)(const MODULE_LOADER* loader, void* config);
+    MODULE_LIBRARY_HANDLE (*Load)(const MODULE_LOADER* loader, void* config);
     /** @brief Unload function, unloads the library from the gateway */    
-    void (*Unload)(const MODULE_LOADER* loader, MODULE_LIBRARY_HANDLE handle);
+    void (*Unload)(const MODULE_LOADER* loader, MODULE_LIBRARY_HANDLE handle);
     /** @brief GetApi function, gets the MODULE_API for the loaded module */  
-    const MODULE_API * (*GetApi)(const MODULE_LOADER* loader, MODULE_LIBRARY_HANDLE handle)
+    const MODULE_API * (*GetApi)(const MODULE_LOADER* loader, MODULE_LIBRARY_HANDLE handle)
 } MODULE_LOADER_API;
 ```
 
@@ -108,7 +108,7 @@ This function is to be implemented by the module loader creator.
 `MODULE_LOADER_API::Load` accepts a void\* as input, and `Gateway_Create` will 
 pass to the loader the `GATEWAY_MODULES_ENTRY::loader_configuration` for the 
 module entry in `GATEWAY_PROPERTIES`.  The module handle should produce an 
-opaque `MODULE_LIBRARY_HANDLE` which will be used for subsequent calls to 
+opaque `MODULE_LIBRARY_HANDLE` which will be used for subsequent calls to 
 `GetApi` and `Unload`.
 
 If the function fails internally, it should return `NULL`.

--- a/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-iot-gateway-connect-device-to-cloud.md
+++ b/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-iot-gateway-connect-device-to-cloud.md
@@ -21,7 +21,7 @@ ms.author: xshi
 # Use IoT gateway to connect things to the cloud - SensorTag to Azure IoT Hub
 
 > [!NOTE]
-> Before you start this tutorial, make sure you’ve completed [Set up Intel NUC as an IoT gateway](iot-hub-gateway-kit-c-lesson1-set-up-nuc.md). In [Set up Intel NUC as an IoT gateway](iot-hub-gateway-kit-c-lesson1-set-up-nuc.md), you set up the Intel NUC device as an IoT gateway.
+> Before you start this tutorial, make sure you've completed [Set up Intel NUC as an IoT gateway](iot-hub-gateway-kit-c-lesson1-set-up-nuc.md). In [Set up Intel NUC as an IoT gateway](iot-hub-gateway-kit-c-lesson1-set-up-nuc.md), you set up the Intel NUC device as an IoT gateway.
 
 ## What you will learn
 

--- a/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-lesson1-set-up-nuc.md
+++ b/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-lesson1-set-up-nuc.md
@@ -100,7 +100,7 @@ Follow these steps to install the package.
 
    > Enter 'y', when it prompts you to 'Include this channel?'
    
-   If you receive an `import read failed(-1)` error, use the following commands to resolve the issue:
+   If you receive an `import read failed(-1)` error, use the following commands to resolve the issue:
    ```bash
    wget http://iotdk.intel.com/misc/iot_pub2.key 
    rpm --import iot_pub2.key  

--- a/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-use-iot-gateway-for-data-conversion.md
+++ b/v1/doc/commercial_gateway_kit/iot-hub-gateway-kit-c-use-iot-gateway-for-data-conversion.md
@@ -21,7 +21,7 @@ ms.author: xshi
 # Use IoT gateway for sensor data transformation with Azure IoT Edge
 
 > [!NOTE]
-> Before you start this tutorial, make sure you’ve completed the following lessons in sequence:
+> Before you start this tutorial, make sure you've completed the following lessons in sequence:
 > * [Set up Intel NUC as an IoT gateway](iot-hub-gateway-kit-c-lesson1-set-up-nuc.md)
 > * [Use IoT gateway to connect things to the cloud - SensorTag to Azure IoT Hub](iot-hub-gateway-kit-c-iot-gateway-connect-device-to-cloud.md)
 
@@ -141,4 +141,4 @@ You get a `libmy_module.so` file after the compile is completed. Make a note of 
 
 ## Next steps
 
-You’ve successfully use the IoT gateway to convert the message from SensorTag into the .json format.
+You've successfully use the IoT gateway to convert the message from SensorTag into the .json format.

--- a/v1/doc/connect_to_preconfigured_solutions/iot-suite-v1-gateway-kit-get-started-sensortag.md
+++ b/v1/doc/connect_to_preconfigured_solutions/iot-suite-v1-gateway-kit-get-started-sensortag.md
@@ -37,7 +37,7 @@ In this tutorial, you complete the following steps:
 To complete this tutorial, you need an active Azure subscription.
 
 > [!NOTE]
-> If you don’t have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
+> If you don't have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
 
 ### Required software
 

--- a/v1/doc/connect_to_preconfigured_solutions/iot-suite-v1-gateway-kit-get-started-simulator.md
+++ b/v1/doc/connect_to_preconfigured_solutions/iot-suite-v1-gateway-kit-get-started-simulator.md
@@ -37,7 +37,7 @@ In this tutorial, you complete the following steps:
 To complete this tutorial, you need an active Azure subscription.
 
 > [!NOTE]
-> If you don’t have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
+> If you don't have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
 
 ### Required software
 

--- a/v1/doc/migration_from_v1_to_v2.md
+++ b/v1/doc/migration_from_v1_to_v2.md
@@ -8,12 +8,12 @@ Continuity of concepts allows existing Azure IoT Edge solutions to be easily mig
 
 ## Overview 
 There are six specific changes that must be accounted for when moving a module from V1 to V2:
-1.	Module format – Modules are implemented as containers instead of DLLs, SOs, jars, .js files or .NET assemblies. 
-2.	Module lifetime -  Modules are started by the IoT Edge runtime and run in their own processes instead of running as a thread in the gateway process. 
-3.	Module configuration – Modules fetch their configuration data from a module twin instead of having it provided as an argument at startup.
-4.	Message passing – Modules use the IoT Edge runtime for sending and receiving messages instead of the broker. 
-5.	Declaring routes – The order in which messages are passed between modules is defined by routes on the IoT Edge runtime instead of links.
-6.	Talking to the cloud – Communication with IoT Hub is provided by the IoT Edge runtime instead of a separate module.
+1.	Module format - Modules are implemented as containers instead of DLLs, SOs, jars, .js files or .NET assemblies. 
+2.	Module lifetime - Modules are started by the IoT Edge runtime and run in their own processes instead of running as a thread in the gateway process. 
+3.	Module configuration - Modules fetch their configuration data from a module twin instead of having it provided as an argument at startup.
+4.	Message passing - Modules use the IoT Edge runtime for sending and receiving messages instead of the broker. 
+5.	Declaring routes - The order in which messages are passed between modules is defined by routes on the IoT Edge runtime instead of links.
+6.	Talking to the cloud - Communication with IoT Hub is provided by the IoT Edge runtime instead of a separate module.
 The following diagram illustrates these changes.
 
 ## Specifics
@@ -21,7 +21,7 @@ Details on each of the migration steps are below. The [tutorial on writing a mod
 
 ### Module format
 Modules allow for creation of units of compute in different languages. They started off with language specific formats. For example: C modules were either a DLLs or SOs, Java modules were jars, and .NET modules were assemblies.
-Module format has changed to the industry standard of containers. This has many benefits, primarily containers…
+Module format has changed to the industry standard of containers. This has many benefits, primarily containers...
 * are an industry standard.
 * include mechanisms for distribution.
 * simplify dependency management on the host system since they include all dependencies for code which runs inside the container.
@@ -47,9 +47,9 @@ Each module now has an individual module twin which can be used to provide a mod
 
 ### Message passing
 Modules used to use a broker inside the gateway process to exchange messages. This functionality is now provided by the IoT Edge runtime.
-* Sending message to the runtime – Call `DeviceClient.SendEventAsync` instead of `Broker_Publish`
-* Receiving a message from the runtime – Register a delegate for receiving messages with `DeviceClient.SetInputMessageHandlerAsync` instead of setting the `pfModule_Receive` function pointer in the `MODULE_API` structure.
-Notice that message passing now uses the same device client code that users are already familiar with when interacting with IoT Hub. The consistency simplifies the number of programing module regardless of whether you’re working in the cloud or on the edge. 
+* Sending message to the runtime - Call `DeviceClient.SendEventAsync` instead of `Broker_Publish`
+* Receiving a message from the runtime - Register a delegate for receiving messages with `DeviceClient.SetInputMessageHandlerAsync` instead of setting the `pfModule_Receive` function pointer in the `MODULE_API` structure.
+Notice that message passing now uses the same device client code that users are already familiar with when interacting with IoT Hub. The consistency simplifies the number of programing module regardless of whether you're working in the cloud or on the edge. 
 
 ### Declaring routes
 The original broker used Links specified in the JSON config file to determine how to pass messages between modules. The IoT Edge runtime uses a very similar concept called routes. Use these when declaring your module pipelines. You can find out more about routes in [this article](https://docs.microsoft.com/en-us/azure/iot-edge/module-composition). 

--- a/v1/doc/module_development/iot-hub-iot-edge-create-module-java.md
+++ b/v1/doc/module_development/iot-hub-iot-edge-create-module-java.md
@@ -53,7 +53,7 @@ Since Azure IoT Edge packages are based on Maven, we need to create a typical Ma
 
 The POM inherits from the `com.microsoft.azure.gateway.gateway-module-base` package, which declares all of the dependencies needed by a module project which includes the runtime binaries, the gateway configuration file path, and the execution behavior. This saves us lots of time and eliminate the need to write and rewrite hundreds of lines of code over and over again.
 
-We need to update the pom.xml file by declaring the required dependencies/plugins and the name of the configuration file to be used by our module as shown in the following code snippet.
+We need to update the pom.xml file by declaring the required dependencies/plugins and the name of the configuration file to be used by our module as shown in the following code snippet.
 
 ```xml
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/v1/proxy/outprocess/devdoc/out-process-control-messages.md
+++ b/v1/proxy/outprocess/devdoc/out-process-control-messages.md
@@ -39,8 +39,8 @@ The basic structure of the control message is simple. It will look like this:
 +----------------------+   --+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This structure is always transmitted over the “wire” in network byte order (big
-endian). Here’s what each of these fields mean:
+This structure is always transmitted over the "wire" in network byte order (big
+endian). Here's what each of these fields mean:
 
 -   **header1** - This is an unsigned byte containing 0xA1.
 
@@ -159,7 +159,7 @@ Module reply
 This message is sent by the module host process to indicate the status of a module. The message `type` field will have the value
 `CONTROL_MESSAGE_TYPE_MODULE_REPLY` and the body of the message is a 
 single unsigned 8-bit value, with 0 indicating success and any non-zero value 
-indicating failure. Here’s what the struct looks like:
+indicating failure. Here's what the struct looks like:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 typedef struct CONTROL_MESSAGE_MODULE_REPLY_TAG

--- a/v1/proxy/outprocess/devdoc/outprocess_hld.md
+++ b/v1/proxy/outprocess/devdoc/outprocess_hld.md
@@ -147,7 +147,7 @@ An example of proxy module configuration with activation.type "launch" :
 
 #### Proxy Module Configuration
 
-The proxy module’s configuration will include the following information:
+The proxy module's configuration will include the following information:
 
 - **name**
 
@@ -205,7 +205,7 @@ The proxy module’s configuration will include the following information:
 
 ### Remote Module Host (a.k.a. Proxy Gateway)
 
-The proxy module’s remote counterpart is a remote module host (*known to the remote module as a proxy gateway*). The remote module host implements the communication protocol for control messages and is responsible for running the remote module and brokering communication between that module and the gateway.
+The proxy module's remote counterpart is a remote module host (*known to the remote module as a proxy gateway*). The remote module host implements the communication protocol for control messages and is responsible for running the remote module and brokering communication between that module and the gateway.
 
 The remote module host does the following:
 
@@ -356,7 +356,7 @@ message packet is structured like so:
     to invoke `Module_Destroy` on the module and quit the process.
 
 
-Alternate Approach - Reusing Broker’s Nanomsg Socket
+Alternate Approach - Reusing Broker's Nanomsg Socket
 ----------------------------------------------------
 
 The topic based routing implementation of the message broker today uses a
@@ -367,7 +367,7 @@ with it from the module host. While this approach works it does not appear to
 obviate the need for:
 
 1.  Having a *proxy* module that represents the module being hosted in the
-    external process because we’d still need a way of *activating* the outprocess
+    external process because we'd still need a way of *activating* the outprocess
     module which, with a proxy module, we could implement from the
     `Module_Create` API.
 
@@ -395,7 +395,7 @@ needed so that the module host knows what topic to publish to when the module
 calls `Broker_Publish`.
 
 With this approach we discover that the module host ends up having to
-re-implement a non-trivial portion of the broker in it’s *proxy broker*
+re-implement a non-trivial portion of the broker in it's *proxy broker*
 implementation. It will for instance, need to re-implement the message loop that
 reads from the *nanomsg* subscribe socket, strip out the topic name from the
 message and deserialize and deliver the message to the module. Similarly, when

--- a/v1/samples/ble_gateway/iot-hub-iot-edge-physical-device.md
+++ b/v1/samples/ble_gateway/iot-hub-iot-edge-physical-device.md
@@ -84,7 +84,7 @@ The following block diagram illustrates the device command data flow pipeline:
 To complete this tutorial, you need an active Azure subscription.
 
 > [!NOTE]
-> If you don’t have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
+> If you don't have an account, you can create a free trial account in just a couple of minutes. For details, see [Azure Free Trial][lnk-free-trial].
 
 You need SSH client on your desktop machine to enable you to remotely access the command line on the Raspberry Pi.
 

--- a/v1/samples/dotnet_core_module_sample/modules/PrinterModule/DotNetPrinterModule.cs
+++ b/v1/samples/dotnet_core_module_sample/modules/PrinterModule/DotNetPrinterModule.cs
@@ -24,15 +24,15 @@ namespace PrinterModule
 
         public void Receive(Message received_message)
         {
-            if (received_message != null)
+            if (received_message != null)
             {
-                string messageData = System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length);
-                Console.WriteLine("{0}> Printer module received message: {1}", DateTime.Now.ToLocalTime(), messageData);
+                string messageData = System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length);
+                Console.WriteLine("{0}> Printer module received message: {1}", DateTime.Now.ToLocalTime(), messageData);
  
-                int propCount = 0;
-                foreach (var prop in received_message.Properties)
+                int propCount = 0;
+                foreach (var prop in received_message.Properties)
                 {
-                    Console.WriteLine("\tProperty[{0}]> Key={1} : Value={2}", propCount++, prop.Key, prop.Value);
+                    Console.WriteLine("\tProperty[{0}]> Key={1} : Value={2}", propCount++, prop.Key, prop.Value);
                 }
             }
         }

--- a/v1/samples/hello_world/iot-hub-linux-iot-edge-get-started.md
+++ b/v1/samples/hello_world/iot-hub-linux-iot-edge-get-started.md
@@ -45,13 +45,13 @@ You can now build the IoT Edge runtime and samples on your local machine:
 
 1. Navigate to the root folder in your local copy of the **iot-edge** repository.
 
-1. Run the build script as follows:
+1. Run the build script as follows:
 
     ```sh
     v1/tools/build.sh --disable-native-remote-modules
     ```
 
-This script uses the **cmake** utility to create a folder called **v1/build** in the root folder of your local copy of the **iot-edge** repository and generate a makefile. The script then builds the solution, skipping unit tests and end to end tests. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.
+This script uses the **cmake** utility to create a folder called **v1/build** in the root folder of your local copy of the **iot-edge** repository and generate a makefile. The script then builds the solution, skipping unit tests and end to end tests. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.
 
 > [!NOTE]
 > Every time you run the **build.sh** script, it deletes and then recreates the **v1/build** folder in the root folder of your local copy of the **iot-edge** repository.
@@ -335,8 +335,8 @@ static void Logger_Receive(MODULE_HANDLE moduleHandle, MESSAGE_HANDLE messageHan
 
 In this article, you ran a simple IoT Edge gateway that writes messages to a log file. To run a sample that sends messages to IoT Hub, see:
 
-- [IoT Edge – send device-to-cloud messages with a simulated device using Linux][lnk-gateway-simulated-linux] 
-- [IoT Edge – send device-to-cloud messages with a simulated device using Windows][lnk-gateway-simulated-windows].
+- [IoT Edge - send device-to-cloud messages with a simulated device using Linux][lnk-gateway-simulated-linux] 
+- [IoT Edge - send device-to-cloud messages with a simulated device using Windows][lnk-gateway-simulated-windows].
 
 
 <!-- Links -->

--- a/v1/samples/hello_world/iot-hub-windows-iot-edge-get-started.md
+++ b/v1/samples/hello_world/iot-hub-windows-iot-edge-get-started.md
@@ -44,7 +44,7 @@ You can now build the IoT Edge runtime and samples on your local machine:
 
 1. Navigate to the root folder in your local copy of the **iot-edge** repository.
 
-1. Run the build script as follows:
+1. Run the build script as follows:
 
     ```cmd
     v1\tools\build.cmd --disable-native-remote-modules
@@ -312,8 +312,8 @@ static void Logger_Receive(MODULE_HANDLE moduleHandle, MESSAGE_HANDLE messageHan
 
 In this article, you ran a simple IoT Edge gateway that writes messages to a log file. To run a sample that sends messages to IoT Hub, see:
 
-- [IoT Edge – send device-to-cloud messages with a simulated device using Linux][lnk-gateway-simulated-linux] 
-- [IoT Edge – send device-to-cloud messages with a simulated device using Windows][lnk-gateway-simulated-windows].
+- [IoT Edge - send device-to-cloud messages with a simulated device using Linux][lnk-gateway-simulated-linux] 
+- [IoT Edge - send device-to-cloud messages with a simulated device using Windows][lnk-gateway-simulated-windows].
 
 
 <!-- Links -->

--- a/v1/samples/simulated_device_cloud_upload/iot-hub-linux-iot-edge-simulated-device.md
+++ b/v1/samples/simulated_device_cloud_upload/iot-hub-linux-iot-edge-simulated-device.md
@@ -45,13 +45,13 @@ You can now build the IoT Edge runtime and samples on your local machine:
 
 1. Navigate to the root folder in your local copy of the **iot-edge** repository.
 
-1. Run the build script as follows:
+1. Run the build script as follows:
 
     ```sh
     tools/build.sh --disable-native-remote-modules
     ```
 
-This script uses the **cmake** utility to create a folder called **v1/build** in the root folder of your local copy of the **iot-edge** repository and generate a makefile. The script then builds the solution, skipping unit tests and end to end tests. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.
+This script uses the **cmake** utility to create a folder called **v1/build** in the root folder of your local copy of the **iot-edge** repository and generate a makefile. The script then builds the solution, skipping unit tests and end to end tests. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.
 
 > [!NOTE]
 > Every time you run the **build.sh** script, it deletes and then recreates the **v1/build** folder in the root folder of your local copy of the **iot-edge** repository.

--- a/v1/samples/simulated_device_cloud_upload/iot-hub-windows-iot-edge-simulated-device.md
+++ b/v1/samples/simulated_device_cloud_upload/iot-hub-windows-iot-edge-simulated-device.md
@@ -44,7 +44,7 @@ You can now build the IoT Edge runtime and samples on your local machine:
 
 1. Navigate to the root folder in your local copy of the **iot-edge** repository.
 
-1. Run the build script as follows:
+1. Run the build script as follows:
 
     ```cmd
     tools\build.cmd --disable-native-remote-modules


### PR DESCRIPTION
Non-ascii characters tend to be a problem for native compilers when the active codepage doesn't support them. We've encountered this several times, especially with snippets from Word documents that make their way into code comments (sometimes Word -> markdown -> code comments). This change replaces most of the characters I found by doing regex file search for "[^\x00-\x7F]" in VS code. It doesn't remove the byte order marks from the beginning of unicode files, and I left a few legalese characters (like the "registered" and "copyright" symbol) which I didn't want to deal with.