### PR TITLE
(#474) Retry when nn_send/recv/close/shutdown is interrupted by a signal

### DIFF
--- a/v1/proxy/gateway/java/nanomsg-binding/java_nanomsg.c
+++ b/v1/proxy/gateway/java/nanomsg-binding/java_nanomsg.c
@@ -43,7 +43,12 @@ JNIEXPORT jint JNICALL Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn
     (void)env;
     (void)obj;
 
-    return nn_close(socket);
+    int result;
+    do
+    {
+        result = nn_close(socket);
+    } while (result == -1 && nn_errno() == EINTR);
+    return result;
 }
 
 JNIEXPORT jint JNICALL Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1bind
@@ -59,7 +64,12 @@ JNIEXPORT jint JNICALL Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn
     (void)env;
     (void)obj;
 
-    return nn_shutdown(socket, endpoint);
+    int result;
+    do
+    {
+        result = nn_shutdown(socket, endpoint);
+    } while (result == -1 && nn_errno() == EINTR);
+    return result;
 }
 
 JNIEXPORT jint JNICALL Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send
@@ -71,12 +81,15 @@ JNIEXPORT jint JNICALL Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn
         jsize length = (*env)->GetArrayLength(env, buffer);
         jbyte* cbuffer = (*env)->GetByteArrayElements(env, buffer, 0);
 
-        if (cbuffer == NULL)
+        if (cbuffer == NULL) 
         {
             result = -1;
         }
         else {
-            result = nn_send(socket, cbuffer, length, flags);
+            do
+            {
+                result = nn_send(socket, cbuffer, length, flags);
+            } while (result == -1 && nn_errno() == EINTR);
             (*env)->ReleaseByteArrayElements(env, buffer, cbuffer, JNI_ABORT);
         }
     }

--- a/v1/proxy/gateway/java/nanomsg-binding/tests/java_nanomsg_ut.c
+++ b/v1/proxy/gateway/java/nanomsg-binding/tests/java_nanomsg_ut.c
@@ -383,6 +383,29 @@ TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1close_s
     ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
 }
 
+TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1close_retries_when_it_is_interrupted)
+{
+    //Arrange
+    umock_c_reset_all_calls();
+
+    jobject jObject = (jobject)0x42;
+    jint socket = (jint)1;
+    jint expectedResult = (jint)0;
+    STRICT_EXPECTED_CALL(nn_close(socket))
+        .SetReturn(-1);
+    STRICT_EXPECTED_CALL(nn_errno())
+        .SetReturn(EINTR);
+    STRICT_EXPECTED_CALL(nn_close(socket))
+        .SetReturn(expectedResult);
+
+    //Act
+    jint result = Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1close(global_env, jObject, socket);
+
+    //Assert
+    ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1bind_success)
 {
     //Arrange
@@ -448,6 +471,30 @@ TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1shutdow
     ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
 }
 
+TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1shutdown_retries_when_it_is_interrupted)
+{
+    //Arrange
+    umock_c_reset_all_calls();
+
+    jobject jObject = (jobject)0x42;
+    jint socket = (jint)1;
+    jint endpoint = (jint)0;
+    jint expectedResult = (jint)0;
+    STRICT_EXPECTED_CALL(nn_shutdown(socket, endpoint))
+        .SetReturn(-1);
+    STRICT_EXPECTED_CALL(nn_errno())
+        .SetReturn(EINTR);
+    STRICT_EXPECTED_CALL(nn_shutdown(socket, endpoint))
+        .SetReturn(expectedResult);
+
+    //Act
+    jint result = Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1shutdown(global_env, jObject, socket, endpoint);
+
+    //Assert
+    ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send_success)
 {
     //Arrange
@@ -471,6 +518,40 @@ TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send_su
 
     //Assert
     ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
+}
+
+TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send_retries_when_it_is_interrupted)
+{
+    //Arrange
+    umock_c_reset_all_calls();
+
+    jobject jObject = (jobject)0x42;
+    jint socket = (jint)1;
+    jbyteArray buffer = (jbyteArray)0x42;
+    jint flags = (jint)1;
+    jint expectedResult = (jint)sizeof(buffer);
+    STRICT_EXPECTED_CALL(GetArrayLength(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments();
+    STRICT_EXPECTED_CALL(GetByteArrayElements(IGNORED_PTR_ARG, IGNORED_PTR_ARG, 0))
+        .IgnoreAllArguments();
+    STRICT_EXPECTED_CALL(nn_send(socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG, flags))
+        .IgnoreArgument(2)
+        .IgnoreArgument(3)
+        .SetReturn(-1);
+    STRICT_EXPECTED_CALL(nn_errno())
+        .SetReturn(EINTR);
+    STRICT_EXPECTED_CALL(nn_send(socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG, flags))
+        .IgnoreArgument(2)
+        .IgnoreArgument(3)
+        .SetReturn(expectedResult);
+    STRICT_EXPECTED_CALL(ReleaseByteArrayElements(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, JNI_ABORT));
+
+    //Act
+    jint result = Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send(global_env, jObject, socket, buffer, flags);
+
+    //Assert
+    ASSERT_ARE_EQUAL(int32_t, expectedResult, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 TEST_FUNCTION(Java_com_microsoft_azure_gateway_remote_NanomsgLibrary_nn_1send_not_sent_if_buffer_is_null)


### PR DESCRIPTION
If calls to our underlying message broker (nanomsg) are interrupted due to a posix signal (on *nix platforms), we interpret that as an error condition and fail. But it's not an error condition, and can actually be quite common (in fact it's more or less guaranteed if a custom module makes use of posix signals, e.g., for events).

This change adds handling logic after calls to nn_send(), nn_recv(), nn_close(), and nn_shutdown() to detect the interrupted condition (nn function returns -1, errno = EINTR) and retry the command as recommended by the nanomsg documentation.

Note that I didn't bother detecting EINTR when NN_DONTWAIT is specified, because in that case the function will return errno = EAGAIN, which we're already handling.

Note also there are some other nanomsg functions that can return EINTR, but I did an audit of our code and these four are the only ones we're using.