### PR TITLE
Support .NET Core modules on macOS

### DIFF
--- a/v1/CMakeLists.txt
+++ b/v1/CMakeLists.txt
@@ -294,6 +294,7 @@ set(dotnet_host_binding_dll ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnet/${CMAKE_
 
 set(dotnet_core_host_binding_dll ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnetcore/$(Configuration)/dotnetcore.dll CACHE INTERNAL "The location of dotnetcore.dll" FORCE)
 set(dotnet_core_host_binding_so ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnetcore/libdotnetcore.so CACHE INTERNAL "The location of libdotnetcore.so" FORCE)
+set(dotnet_core_host_binding_dylib ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnetcore/libdotnetcore.dylib CACHE INTERNAL "The location of libdotnetcore.dylib" FORCE)
 
 set(dotnet_core_managed_binding_dll ${CMAKE_CURRENT_BINARY_DIR}/../bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/Microsoft.Azure.Devices.Gateway.dll CACHE INTERNAL "The location of the Microsoft.Azure.Devices.Gateway.dll" FORCE)
 set(dotnet_core_e2etest_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../bindings/dotnetcore/dotnet-core-binding/E2ETestModule/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/E2ETestModule.dll CACHE INTERNAL "The location of the E2ETestModule.dll" FORCE)

--- a/v1/bindings/dotnetcore/CMakeLists.txt
+++ b/v1/bindings/dotnetcore/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 if(WIN32)
     set(dotnetcore_utils_file ./src/adapters/dotnetcore_utils_windows.cpp)
-elseif(LINUX)
+elseif(UNIX) #LINUX or APPLE
     set(dotnetcore_utils_file ./src/adapters/dotnetcore_utils_linux.cpp)
 endif()
 
@@ -26,7 +26,7 @@ include_directories(${GW_INC})
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
 
 #this builds the dotnet core dynamic library
-add_library(dotnetcore MODULE ${dotnet_core_sources} ${dotnet_core_headers})
+add_library(dotnetcore SHARED ${dotnet_core_sources} ${dotnet_core_headers})
 target_link_libraries(dotnetcore gateway)
 
 #this builds the dotnet core static library

--- a/v1/bindings/dotnetcore/CMakeLists.txt
+++ b/v1/bindings/dotnetcore/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(dotnet_core_static gateway)
 linkSharedUtil(dotnetcore)
 linkSharedUtil(dotnet_core_static)
 
-if(${run_unittests})
+if(${run_unittests} OR ${run_e2e_tests})
     add_subdirectory(tests)
 endif()
 

--- a/v1/bindings/dotnetcore/src/adapters/dotnetcore_utils_linux.cpp
+++ b/v1/bindings/dotnetcore/src/adapters/dotnetcore_utils_linux.cpp
@@ -12,6 +12,9 @@
 #include <dirent.h>
 #include <set>
 #include <sys/stat.h>
+#ifdef __APPLE__
+#include <sys/syslimits.h>
+#endif
 
 
 

--- a/v1/bindings/dotnetcore/tests/CMakeLists.txt
+++ b/v1/bindings/dotnetcore/tests/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required(VERSION 2.8.12)
 
 add_definitions(-DUNDER_TEST)
 
-add_subdirectory(dotnetcore_ut)
+if(${run_unittests})
+    add_subdirectory(dotnetcore_ut)
+endif()
 
-add_subdirectory(dotnetcore_e2e)
+if(${run_e2e_tests})
+    add_subdirectory(dotnetcore_e2e)
+endif()

--- a/v1/bindings/dotnetcore/tests/dotnetcore_e2e/CMakeLists.txt
+++ b/v1/bindings/dotnetcore/tests/dotnetcore_e2e/CMakeLists.txt
@@ -50,6 +50,8 @@ install_binaries(${theseTestsName}_exe ${CMAKE_CURRENT_BINARY_DIR}/$(Configurati
 
 if(WIN32)
     install_binaries(${theseTestsName}_exe ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_dll} )
+elseif(APPLE)
+    install_binaries(${theseTestsName}_exe ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_dylib} )
 else()
     install_binaries(${theseTestsName}_exe ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_so} )
 endif()

--- a/v1/core/CMakeLists.txt
+++ b/v1/core/CMakeLists.txt
@@ -283,7 +283,7 @@ if(NOT ${use_xplat_uuid})
 endif()
 
 #this adds the tests to the build process
-if(${run_unittests})
+if(${run_unittests} OR ${run_e2e_tests})
     add_subdirectory(tests)
 endif()
 

--- a/v1/core/inc/module_loaders/dotnet_core_loader.h
+++ b/v1/core/inc/module_loaders/dotnet_core_loader.h
@@ -28,7 +28,7 @@ extern "C"
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "dotnetcore.dll"
 #define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll"
 #define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
-#elif APPLE
+#elif __APPLE__
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "libdotnetcore.dylib"
 #define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/libcoreclr.so"
 #define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/"

--- a/v1/core/inc/module_loaders/dotnet_core_loader.h
+++ b/v1/core/inc/module_loaders/dotnet_core_loader.h
@@ -28,6 +28,10 @@ extern "C"
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "dotnetcore.dll"
 #define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll"
 #define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
+#elif APPLE
+#define DOTNET_CORE_BINDING_MODULE_NAME                                "libdotnetcore.dylib"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/libcoreclr.so"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/"
 #else
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "libdotnetcore.so"
 #define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/libcoreclr.so"

--- a/v1/jenkins/osx_c.sh
+++ b/v1/jenkins/osx_c.sh
@@ -10,6 +10,7 @@ OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
 tools/build.sh \
     --disable-ble-module \
     --enable-java-binding \
+    --enable-dotnet-core-binding \
     --enable-java-remote-modules \
     --enable-nodejs-remote-modules \
     --run-unittests \

--- a/v1/samples/dotnet_core_module_sample/CMakeLists.txt
+++ b/v1/samples/dotnet_core_module_sample/CMakeLists.txt
@@ -39,6 +39,8 @@ install_binaries(dotnet_core_module_sample ${CMAKE_CURRENT_BINARY_DIR}/$(Configu
 
 if(WIN32)
     install_binaries(dotnet_core_module_sample ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_dll} )
+elseif(APPLE)
+    install_binaries(dotnet_core_module_sample ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_dylib} )
 else()
     install_binaries(dotnet_core_module_sample ${CMAKE_CURRENT_BINARY_DIR}/$(Configuration) ${dotnet_core_host_binding_so} )
 endif()

--- a/v1/samples/dotnet_core_module_sample/README.md
+++ b/v1/samples/dotnet_core_module_sample/README.md
@@ -4,13 +4,12 @@
 Overview
 --------
 
-This sample showcases how one might build modules for IoT gateway in .NET Core.
+This sample showcases how to build .NET Core modules for IoT Edge.
 
 The sample contains:
 
-1. A printer module (C#) that interprets telemetry from sensor and prints its content and properties into Console.
-2. A sensor module (C#) that publishes random data to the gateway.
-3. A logger module for producing message broker diagnostics.
+1. A sensor module (C#) that sends randomly-generated temperature values.
+2. A printer module (C#) that receives sensor data and prints it to the console.
 
 Other resources:
 - Hello World [sample](../hello_world/README.md)
@@ -20,140 +19,64 @@ Other resources:
 Prerequisites
 --------------
 1. Setup your development machine. A guide for doing this can be found [here](../../doc/devbox_setup.md).
-2. Make sure you have .NET Core Framework installed. Our current version of the binding was tested and loads modules written in .NET **Core** v1.1.1.
+2. Make sure you have .NET Core installed. Our current version of the binding was tested and loads modules written in .NET Core v1.1.1.
 
 Building the sample
 -------------------
-The sample gateway gets built when you build Azure IoT Edge by first running
+The sample IoT Edge application and modules are built with the following command:
 ```
 tools\build.cmd --enable-dotnet-core-binding
 ```
 
 The [devbox setup](../../doc/devbox_setup.md) guide has more information on how you can build Azure IoT Edge.
 
-The `build_dotnet_core.cmd` script builds the .NET Core binding, and the sample sensor and printer modules.
-Building the solution you will have the following binaries: 
-1. Microsoft.Azure.Devices.Gateway.dll
-2. SensorModule.dll
-3. PrinterModule.dll
-
-Running the sample
-------------------
-1. Open azure_iot_gateway_sdk solution and configure project `dotnet_core_module_sample` as a Startup Sample.
-2. Go to the Project Properties and change `Command Arguments` to point to dotnet_core_module_sample.json.
-3. Run.
-
-
-
-
-Json Configuration
-------------------
-```json
-{
-    "modules": [
-        {
-            "name": "logger",
-            "loader": {
-                "name": "native",
-                "entrypoint": {
-                    "module.path": "..\\..\\..\\modules\\logger\\Debug\\logger.dll"
-                }
-            },
-            "args": { "filename": "C:\\Temp\\Log.txt" }
-        },
-        {
-            "name": "dotnet_sensor_module",
-            "loader": {
-                "name": "dotnetcore",
-                "entrypoint": {
-
-                    "assembly.name": "SensorModule",
-                    "entry.type": "SensorModule.DotNetSensorModule"
-                }
-            },
-            "args": "module configuration"
-        },
-        {
-            "name": "dotnet_printer_module",
-            "loader": {
-                "name": "dotnetcore",
-                "entrypoint": {
-                    "assembly.name": "PrinterModule",
-                    "entry.type": "PrinterModule.DotNetPrinterModule"
-                }
-            },
-            "args": "module configuration"
-        }
-    ],
-    "links": [
-      {"source": "dotnet_sensor_module", "sink": "dotnet_printer_module" }
-    ]
-}
+Running the sample (Windows)
+----------------------------
+1. Navigate to the **v1/build** folder in your local copy of the **iot-edge** repository.
+2. Run the following command:
 ```
+samples\dotnet_core_module_sample\Debug\dotnet_core_module_sample.exe ..\samples\dotnet_core_module_sample\src\dotnet_core_module_sample_win.json
+```
+
+Running the sample (Linux)
+----------------------------
+1. Navigate to the **v1/build/samples/dotnet_core_module_sample** folder in your local copy of the **iot-edge** repository.
+2. Run the following command:
+```
+./dotnet_core_module_sample ../../../samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json
+```
+
 
 Creating your own module
 ------------------------
-1. Create a .NET Core project (DLL) (Class library).
-2. Add Reference to Microsoft.Azure.Devices.Gateway DLL.
-3. On your class you shall implement `IGatewayModule`.
-   See the Printer module as example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C#
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Gateway;
+1. Create a .NET Core project (Class library).
+2. Add a reference to the .NET Core binding, Microsoft.Azure.Devices.Gateway.dll.
+3. Inherit `IGatewayModule` in your module class, and implement `Create`, `Destroy`, and `Receive`.
 
+   _For examples, see the sample [Printer](modules/PrinterModule/DotNetPrinterModule.cs) and [Sensor](modules/SensorModule/DotNetSensorModule.cs) modules._
 
-namespace PrinterModule
-{
-    public class DotNetPrinterModule : IGatewayModule
-    {
-        private string configuration;
-        public void Create(Broker broker, byte[] configuration)
-        {
-            this.configuration = System.Text.Encoding.UTF8.GetString(configuration);
-        }
-
-        public void Destroy()
-        {
-        }
-
-        public void Receive(Message received_message)
-        {
-            if(received_message.Properties["source"] == "sensor")
-            {
-                Console.WriteLine("Printer Module received message from Sensor. Content: " + System.Text.Encoding.UTF8.GetString(received_message.Content, 0, received_message.Content.Length));
-            }
-        }
-    }
-}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Modules may also implement the `IGatewayModuleStart` interface.  The Start method is called when the gateway's Broker is ready for the module to send and receive messages. 
-
-4. Add your new module on Json configuration:
+4. Optionally inherit `IGatewayModuleStart` in your module class, and implement `Start`. `Start` is called when the broker is ready to send and receive messages.
+5. Add your new module to your application's JSON configuration:
 ```json
 {
     "modules" :
     [
         {
-            "name": "dotnet_printer_module", ==> Your new module name. 
+            "name": "my_module",
             "loader": {
                 "name": "dotnetcore",
                 "entrypoint": {
-
-                    "assembly.name": "SensorModule",==> This is the name of your module dll. On this sample it is SensorModule.dll
-                    "entry.type": "SensorModule.DotNetSensorModule" ==> This is the name of your Class (Namespace.ClassName) that implements IGatewayModule.
+                    "assembly.name": "MyModule",
+                    "entry.type": "MyModule.ModuleClass"
                 }
             },
-            "args": "module configuration"  ==> This is any configuration you want to use on your sample. It will be passed to you as a byte[] that should be converted to an UTF-8 Encoded String, you can add a JSON configuration in it.
+            "args": "whatever my module needs, as a UTF-8 string"
         }
     ]
 }
 ```
-5. If you want to load .NET Core CLR from a different location you can add a `loader` item on your JSON Configuration. Sample with CLR path:
+
+6. If you want to override the default locations for the .NET Core binding (dotnetcore.dll/libdotnetcore.so) or the .NET Core runtime (coreclr.dll/libcoreclr.so, and path to trusted platform assemblies), add an item to the `loaders` array in your JSON configuration. For example:
 ```json
 {
      "loaders": [
@@ -161,26 +84,11 @@ Modules may also implement the `IGatewayModuleStart` interface.  The Start metho
             "type": "dotnetcore",
             "name": "dotnetcore",
             "configuration": {
-                "binding.path": "..\\..\\..\\bindings\\dotnetcore\\Debug\\dotnetcore.dll",
-                "binding.coreclrpath": "<Path to your .NET Core Path.>",
-                "binding.trustedplatformassemblieslocation": "<Path to find trusted platform assemblies, used by CLR."
+                "binding.path": "path/to/libdotnetcore.so",
+                "binding.coreclrpath": "path/to/libcoreclr.so",
+                "binding.trustedplatformassemblieslocation": "path/to/trusted/platform/assemblies"
             }
         }
     ],
-    "modules" :
-    [
-        {
-            "name": "dotnet_printer_module", ==> Your new module name. 
-            "loader": {
-                "name": "dotnetcore",
-                "entrypoint": {
-
-                    "assembly.name": "SensorModule",==> This is the name of your module dll. On this sample it is SensorModule.dll
-                    "entry.type": "SensorModule.DotNetSensorModule" ==> This is the name of your Class (Namespace.ClassName) that implements IGatewayModule.
-                }
-            },
-            "args": "module configuration"  ==> This is any configuration you want to use on your sample. It will be passed to you as a byte[] that should be converted to an UTF-8 Encoded String, you can add a JSON configuration in it.
-        }
-    ]
 }
 ```

--- a/v1/samples/dotnet_core_module_sample/README.md
+++ b/v1/samples/dotnet_core_module_sample/README.md
@@ -24,8 +24,15 @@ Prerequisites
 Building the sample
 -------------------
 The sample IoT Edge application and modules are built with the following command:
+
+(Windows)
 ```
 tools\build.cmd --enable-dotnet-core-binding
+```
+
+(Linux or Mac)
+```
+tools/build.sh --enable-dotnet-core-binding
 ```
 
 The [devbox setup](../../doc/devbox_setup.md) guide has more information on how you can build Azure IoT Edge.
@@ -38,10 +45,15 @@ Running the sample (Windows)
 samples\dotnet_core_module_sample\Debug\dotnet_core_module_sample.exe ..\samples\dotnet_core_module_sample\src\dotnet_core_module_sample_win.json
 ```
 
-Running the sample (Linux)
+Running the sample (Linux or macOS)
 ----------------------------
 1. Navigate to the **v1/build/samples/dotnet_core_module_sample** folder in your local copy of the **iot-edge** repository.
-2. Run the following command:
+2. In **../../../samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json**, update the values of `binding.coreclrpath` and `binding.trustedplatformassemblieslocation` under `loaders.configuration`. `binding.coreclrpath` should be the path to libcoreclr.so (libcoreclr.dylib on macOS) in your .NET Core installation, In a typical installation, `binding.trustedplatformassemblieslocation` can be set to parent folder of "coreclrpath". For example (typical installation on macOS):
+```
+    "binding.coreclrpath": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.6/libcoreclr.dylib",
+    "binding.trustedplatformassemblieslocation": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.6"
+```
+3. Run the following command:
 ```
 ./dotnet_core_module_sample ../../../samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json
 ```
@@ -76,7 +88,7 @@ Creating your own module
 }
 ```
 
-6. If you want to override the default locations for the .NET Core binding (dotnetcore.dll/libdotnetcore.so) or the .NET Core runtime (coreclr.dll/libcoreclr.so, and path to trusted platform assemblies), add an item to the `loaders` array in your JSON configuration. For example:
+6. If you want to override the default locations for the .NET Core binding (dotnetcore.dll/libdotnetcore.so/libdotnetcore.dylib) or the .NET Core runtime (coreclr.dll/libcoreclr.so/libcoreclr.dylib, and path to trusted platform assemblies), add an item to the `loaders` array in your JSON configuration. For example:
 ```json
 {
      "loaders": [
@@ -84,8 +96,8 @@ Creating your own module
             "type": "dotnetcore",
             "name": "dotnetcore",
             "configuration": {
-                "binding.path": "path/to/libdotnetcore.so",
-                "binding.coreclrpath": "path/to/libcoreclr.so",
+                "binding.path": "path/to/dotnetcore/binding",
+                "binding.coreclrpath": "path/to/coreclr/library",
                 "binding.trustedplatformassemblieslocation": "path/to/trusted/platform/assemblies"
             }
         }

--- a/v1/samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json
+++ b/v1/samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json
@@ -1,5 +1,15 @@
 {
-  "modules": [
+    "loaders": [
+        {
+            "type": "dotnetcore",
+            "name": "dotnetcore",
+            "configuration": {
+                "binding.coreclrpath": "path/to/coreclr",
+                "binding.trustedplatformassemblieslocation": "path/to/trusted/platform/assemblies"
+            }
+        }
+    ],
+    "modules": [
         {
             "name": "dotnet_sensor_module",
             "loader": {
@@ -10,8 +20,8 @@
                 }
             },
             "args": "module configuration"
-    },
-    {
+        },
+        {
             "name": "dotnet_printer_module",
             "loader": {
                 "name": "dotnetcore",
@@ -21,12 +31,12 @@
                 }
             },
             "args": "module configuration"
-    }
-  ],
-  "links": [
-    {
-      "source": "dotnet_sensor_module",
-      "sink": "dotnet_printer_module"
-    }
-  ]
+        }
+    ],
+    "links": [
+        {
+            "source": "dotnet_sensor_module",
+            "sink": "dotnet_printer_module"
+        }
+    ]
 }


### PR DESCRIPTION
With these changes, I can run `./dotnet_core_module_sample` on macOS (I haven't yet tried dotnet_core_managed_gateway).