### PR TITLE
netcore 2.0

### DIFF
--- a/v1/CMakeLists.txt
+++ b/v1/CMakeLists.txt
@@ -297,9 +297,9 @@ set(dotnet_core_host_binding_so ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnetcore/
 set(dotnet_core_host_binding_dylib ${CMAKE_CURRENT_BINARY_DIR}/bindings/dotnetcore/libdotnetcore.dylib CACHE INTERNAL "The location of libdotnetcore.dylib" FORCE)
 
 set(dotnet_core_managed_binding_dll ${CMAKE_CURRENT_BINARY_DIR}/../bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/Microsoft.Azure.Devices.Gateway.dll CACHE INTERNAL "The location of the Microsoft.Azure.Devices.Gateway.dll" FORCE)
-set(dotnet_core_e2etest_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../bindings/dotnetcore/dotnet-core-binding/E2ETestModule/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/E2ETestModule.dll CACHE INTERNAL "The location of the E2ETestModule.dll" FORCE)
-set(dotnet_core_sensor_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../samples/dotnet_core_module_sample/modules/SensorModule/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/SensorModule.dll CACHE INTERNAL "The location of the SensorModule.dll" FORCE)
-set(dotnet_core_printer_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../samples/dotnet_core_module_sample/modules/PrinterModule/bin/${CMAKE_BUILD_TYPE}/netstandard1.3/PrinterModule.dll CACHE INTERNAL "The location of the PrinterModule.dll" FORCE)
+set(dotnet_core_e2etest_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../bindings/dotnetcore/dotnet-core-binding/E2ETestModule/bin/${CMAKE_BUILD_TYPE}/netstandard2.0/E2ETestModule.dll CACHE INTERNAL "The location of the E2ETestModule.dll" FORCE)
+set(dotnet_core_sensor_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../samples/dotnet_core_module_sample/modules/SensorModule/bin/${CMAKE_BUILD_TYPE}/netstandard2.0/SensorModule.dll CACHE INTERNAL "The location of the SensorModule.dll" FORCE)
+set(dotnet_core_printer_module_dll ${CMAKE_CURRENT_BINARY_DIR}/../samples/dotnet_core_module_sample/modules/PrinterModule/bin/${CMAKE_BUILD_TYPE}/netstandard2.0/PrinterModule.dll CACHE INTERNAL "The location of the PrinterModule.dll" FORCE)
 
 function(install_binaries whatIsBuilding whatIsBuildingLocation whatIsBinaryLocation)
   add_custom_command(TARGET ${whatIsBuilding} POST_BUILD

--- a/v1/bindings/dotnetcore/dotnet-core-binding/E2ETestModule/E2ETestModule.csproj
+++ b/v1/bindings/dotnetcore/dotnet-core-binding/E2ETestModule/E2ETestModule.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>E2ETestModule</AssemblyName>
     <PackageId>E2ETestModule</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.3</PackageVersion>
+	<PackageVersion>1.0.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/v1/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway.Tests/Microsoft.Azure.Devices.Gateway.Tests.csproj
+++ b/v1/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway.Tests/Microsoft.Azure.Devices.Gateway.Tests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Azure.Devices.Gateway.Tests</AssemblyName>
     <PackageId>Microsoft.Azure.Devices.Gateway.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
-	<PackageVersion>1.0.3</PackageVersion>
+    <RuntimeFrameworkVersion>2.0.7</RuntimeFrameworkVersion>
+	<PackageVersion>1.0.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/v1/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/Microsoft.Azure.Devices.Gateway.csproj
+++ b/v1/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/Microsoft.Azure.Devices.Gateway.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.3</PackageVersion>
+	<PackageVersion>1.0.6</PackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/v1/bindings/dotnetcore/src/adapters/dotnetcore_utils_linux.cpp
+++ b/v1/bindings/dotnetcore/src/adapters/dotnetcore_utils_linux.cpp
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #ifdef __APPLE__
 #include <sys/syslimits.h>
+#include <mach-o/dyld.h>
 #endif
 
 
@@ -120,7 +121,12 @@ bool initializeDotNetCoreCLR(coreclr_initialize_ptr coreclrInitialize_ptr, const
     char the_p_path[PATH_MAX];
 
     //Ignoring failures of these calls. coreclrInitialize_ptr will fail if folder is not right. 
+#ifdef __APPLE__
+    uint32_t size = PATH_MAX;
+    _NSGetExecutablePath(executableFullPath, &size);
+#else
     (void)readlink("/proc/self/exe", executableFullPath, sizeof(executableFullPath));
+#endif
     getcwd(the_p_path, 255);
     strcat(the_p_path, "/");
 

--- a/v1/core/devdoc/dotnet_core_loader_requirements.md
+++ b/v1/core/devdoc/dotnet_core_loader_requirements.md
@@ -18,12 +18,12 @@ Exposed API
 
 #if WIN32
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "dotnetcore.dll"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.0.1\\coreclr.dll"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.0.1\\"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\coreclr.dll"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\"
 #else
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "./libdotnetcore.so"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/share/dotnet/shared/Microsoft.NETCore.App/1.1.0/libcoreclr.so"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/share/dotnet/shared/Microsoft.NETCore.App/1.1.0/"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/libcoreclr.so"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/"
 #endif
 
 #define DOTNET_CORE_CLR_PATH_KEY                                "binding.coreclrpath"

--- a/v1/core/inc/module_loaders/dotnet_core_loader.h
+++ b/v1/core/inc/module_loaders/dotnet_core_loader.h
@@ -22,20 +22,20 @@ extern "C"
 
 #ifdef _WIN64
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "dotnetcore.dll"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\coreclr.dll"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\"
 #elif WIN32
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "dotnetcore.dll"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\coreclr.dll"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "C:\\Program Files (x86)\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\"
 #elif __APPLE__
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "libdotnetcore.dylib"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/libcoreclr.so"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/libcoreclr.dylib"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/"
 #else
 #define DOTNET_CORE_BINDING_MODULE_NAME                                "libdotnetcore.so"
-#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/libcoreclr.so"
-#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/share/dotnet/shared/Microsoft.NETCore.App/1.1.1/"
+#define DOTNET_CORE_CLR_PATH_DEFAULT                                   "/usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/libcoreclr.so"
+#define DOTNET_CORE_TRUSTED_PLATFORM_ASSEMBLIES_LOCATION_DEFAULT       "/usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/"
 #endif
 
 #define DOTNET_CORE_CLR_PATH_KEY                                "binding.coreclrpath"

--- a/v1/doc/module_development/iot-hub-iot-edge-create-module-dotnet-core.md
+++ b/v1/doc/module_development/iot-hub-iot-edge-create-module-dotnet-core.md
@@ -50,7 +50,7 @@ View this [quick video tutorial](https://channel9.msdn.com/Blogs/dotnet/Get-star
 1. Initialize a new `.NET Core` class library C# project:
 	- Open a command prompt (`Windows + R` -> `cmd` -> `enter`).
 	- Navigate to the folder where you'd like to create the `C#` project.
-	- Type **dotnet new classlib -o IoTEdgeConverterModule -f netstandard1.3**. 
+	- Type **dotnet new classlib -o IoTEdgeConverterModule -f netstandard2.0**. 
 	- This command creates an empty class called `Class1.cs` in your projects directory.
 2. Navigate to the folder where we just created the class library project by typing **cd IoTEdgeConverterModule**.
 3. Open the project in `Visual Studio Code` by typing **code .**.
@@ -271,8 +271,8 @@ View this [quick video tutorial](https://channel9.msdn.com/Blogs/dotnet/Get-star
                "name": "dotnetcore",
                "configuration": {
                    "binding.path": "dotnetcore.dll",
-                   "binding.coreclrpath": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll",
-                   "binding.trustedplatformassemblieslocation": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
+                   "binding.coreclrpath": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\coreclr.dll",
+                   "binding.trustedplatformassemblieslocation": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\"
                }
            }
        ],
@@ -344,13 +344,13 @@ View this [quick video tutorial](https://channel9.msdn.com/Blogs/dotnet/Get-star
 24. Copy and paste the following code snippet into the `Untitled-1` file.
 
    ```powershell
-   Copy-Item -Path $env:userprofile\.nuget\packages\microsoft.azure.devices.gateway.native.windows.x64\1.1.3\runtimes\win-x64\native\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\system.runtime.serialization.formatters\4.3.0\lib\netstandard1.4\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\system.runtime.serialization.primitives\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\newtonsoft.json\10.0.2\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\system.componentmodel.typeconverter\4.3.0\lib\netstandard1.5\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\system.collections.nongeneric\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard1.3
-   Copy-Item -Path $env:userprofile\.nuget\packages\system.collections.specialized\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard1.3
+   Copy-Item -Path $env:userprofile\.nuget\packages\microsoft.azure.devices.gateway.native.windows.x64\1.1.3\runtimes\win-x64\native\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\system.runtime.serialization.formatters\4.3.0\lib\netstandard1.4\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\system.runtime.serialization.primitives\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\newtonsoft.json\10.0.2\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\system.componentmodel.typeconverter\4.3.0\lib\netstandard1.5\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\system.collections.nongeneric\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard2.0
+   Copy-Item -Path $env:userprofile\.nuget\packages\system.collections.specialized\4.3.0\lib\netstandard1.3\* -Destination .\bin\Debug\netstandard2.0
    ```
 
 25. Save the file as `binplace.ps1` by pressing `Ctrl` + `Shift` + `S`.
@@ -370,7 +370,7 @@ View this [quick video tutorial](https://channel9.msdn.com/Blogs/dotnet/Get-star
 
 27.  Open the `Visual Studio Code` integrated terminal window by pressing the `Ctrl` + `backtick` keys or using the menus `View` -> `Integrated Terminal` and type **.\binplace.ps1** into the `PowerShell` command prompt. This command copies all our dependencies to the output directory.
 
-28. Navigate to the projects output directory in the `Integrated Terminal` window by typing **cd .\bin\Debug\netstandard1.3**.
+28. Navigate to the projects output directory in the `Integrated Terminal` window by typing **cd .\bin\Debug\netstandard2.0**.
 
 29. Run the sample project by typing **.\gw.exe gw-config.json** into the `Integrated Terminal` window prompt. 
     - If you have followed the steps in this tutorial closely, you should now be running the `Azure IoT Edge BLE Data Converter Module` sample project as seen in the following image:

--- a/v1/samples/dotnet_core_dynamic_add_module/README.md
+++ b/v1/samples/dotnet_core_dynamic_add_module/README.md
@@ -18,7 +18,7 @@ Other resources:
 Prerequisites
 --------------
 1. Setup your development machine. A guide for doing this can be found [here](../../doc/devbox_setup.md).
-2. Make sure you have .NET Core Framework installed. Our current version of the binding was tested and loads modules written in .NET **Core** v1.1.1.
+2. Make sure you have .NET Core Framework installed. Our current version of the binding was tested and loads modules written in .NET **Core** v2.0.7.
 
 Building the sample (Linux)
 ---------------------------

--- a/v1/samples/dotnet_core_dynamic_add_module/dotnet_core_dynamic_add_module.csproj
+++ b/v1/samples/dotnet_core_dynamic_add_module/dotnet_core_dynamic_add_module.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/v1/samples/dotnet_core_managed_gateway/README.md
+++ b/v1/samples/dotnet_core_managed_gateway/README.md
@@ -21,7 +21,7 @@ Other resources:
 Prerequisites
 --------------
 1. Setup your development machine. A guide for doing this can be found [here](../../doc/devbox_setup.md).
-2. Make sure you have .NET Core Framework installed. Our current version of the binding was tested and loads modules written in .NET **Core** v1.1.1.
+2. Make sure you have .NET Core Framework installed. Our current version of the binding was tested and loads modules written in .NET **Core** v2.0.7.
 
 Building the sample
 -------------------

--- a/v1/samples/dotnet_core_managed_gateway/dotnet_core_managed_gateway.csproj
+++ b/v1/samples/dotnet_core_managed_gateway/dotnet_core_managed_gateway.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/v1/samples/dotnet_core_module_sample/README.md
+++ b/v1/samples/dotnet_core_module_sample/README.md
@@ -19,7 +19,7 @@ Other resources:
 Prerequisites
 --------------
 1. Setup your development machine. A guide for doing this can be found [here](../../doc/devbox_setup.md).
-2. Make sure you have .NET Core installed. Our current version of the binding was tested and loads modules written in .NET Core v1.1.1.
+2. Make sure you have .NET Core installed. Our current version of the binding was tested and loads modules written in .NET Core v2.0.7.
 
 Building the sample
 -------------------
@@ -50,8 +50,8 @@ Running the sample (Linux or macOS)
 1. Navigate to the **v1/build/samples/dotnet_core_module_sample** folder in your local copy of the **iot-edge** repository.
 2. In **../../../samples/dotnet_core_module_sample/src/dotnet_core_module_sample_lin.json**, update the values of `binding.coreclrpath` and `binding.trustedplatformassemblieslocation` under `loaders.configuration`. `binding.coreclrpath` should be the path to libcoreclr.so (libcoreclr.dylib on macOS) in your .NET Core installation, In a typical installation, `binding.trustedplatformassemblieslocation` can be set to parent folder of "coreclrpath". For example (typical installation on macOS):
 ```
-    "binding.coreclrpath": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.6/libcoreclr.dylib",
-    "binding.trustedplatformassemblieslocation": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.6"
+    "binding.coreclrpath": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/2.0.7/libcoreclr.dylib",
+    "binding.trustedplatformassemblieslocation": "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/2.0.7"
 ```
 3. Run the following command:
 ```

--- a/v1/samples/dotnet_core_module_sample/modules/PrinterModule/PrinterModule.csproj
+++ b/v1/samples/dotnet_core_module_sample/modules/PrinterModule/PrinterModule.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>PrinterModule</AssemblyName>
     <PackageId>PrinterModule</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.3</PackageVersion>
+	<PackageVersion>1.0.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/v1/samples/dotnet_core_module_sample/modules/SensorModule/SensorModule.csproj
+++ b/v1/samples/dotnet_core_module_sample/modules/SensorModule/SensorModule.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>SensorModule</AssemblyName>
     <PackageId>SensorModule</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.3</PackageVersion>
+	<PackageVersion>1.0.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/v1/samples/dotnet_core_module_sample/src/dotnet_core_module_sample_win.json
+++ b/v1/samples/dotnet_core_module_sample/src/dotnet_core_module_sample_win.json
@@ -5,8 +5,8 @@
             "name": "dotnetcore",
             "configuration": {
                 "binding.path": "dotnetcore.dll",
-                "binding.coreclrpath": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\coreclr.dll",
-                "binding.trustedplatformassemblieslocation": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\1.1.1\\"
+                "binding.coreclrpath": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\coreclr.dll",
+                "binding.trustedplatformassemblieslocation": "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\2.0.7\\"
             }
         }
     ],


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#567

# Description of the problem
.NET Core 2.0 changes

# Description of the solution
1. Using dotnetcore 2.0.7 runtime
2. Samples and tests moved to netstandard 2.0/netcore 2.0
3. Nuget Microsoft.Azure.Devices.Gateway left unchanged on netstandard 1.3

## Notes on Unit Tests 
1. Tested only on Ubuntu 16.04 LTS and macOS 10.12.3 (flags: --run-unittests --run-e2e-tests). All unit tests passed. All e2e tests except gateway_e2e passed (no connection string in environment).

## Not sure
1. Not tested on Windows
2. `_NSGetExecutablePath` failure not checked as was the case for nearby `readlink` with comment
3. macOS platform preprocessor (APPLE) in source code as the file already had the same preprocessor check
4. csproj versions changed to 1.0.6