### PR TITLE
Added Message ContentEncoding and ContentType

### DIFF
--- a/v2/samples/azureiotedge-simulated-temperature-sensor/Program.cs
+++ b/v2/samples/azureiotedge-simulated-temperature-sensor/Program.cs
@@ -142,6 +142,8 @@ namespace AzureIotEdgeSimulatedTemperatureSensor
                         var messageString = JsonConvert.SerializeObject(messageBody);
                         var messageBytes = Encoding.UTF8.GetBytes(messageString);
                         var message = new Message(messageBytes);
+                        message.ContentEncoding = "utf-8"; 
+                        message.ContentType = "application/json"; 
 
                         await deviceClient.SendEventAsync("temperatureOutput", message);
                         Console.WriteLine($"\t{DateTime.UtcNow.ToShortDateString()} {DateTime.UtcNow.ToLongTimeString()}> Sending message: {counter}, Body: {messageString}");


### PR DESCRIPTION
Required properties to enable routing on those messages with body content


# Description of the problem
Constructed message does not contain ContentType and ContentEncoding. Hence conditional message routing based on message body content is not possible in IoT (Edge) Hub

# Description of the solution
Just added the two missing properties to the message header
